### PR TITLE
Add AdaFace IR-18 face recognition demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,8 @@ Pastel Mix - a stylized latent diffusion model.This model is intended to produce
 
 AdaFace — Quality-adaptive face recognition. Outputs 512-dim embedding for face verification and identification.
 
+<img width="300" src="https://github.com/user-attachments/assets/e5938858-9560-4aaf-9d21-f0059daa255e">
+
 | Download Link | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
 | [AdaFace_IR18.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/adaface-v1/AdaFace_IR18.mlpackage.zip) | 48 MB | Image (112×112 face) | 512-dim L2-normalized embedding | [mk-minchul/AdaFace](https://github.com/mk-minchul/AdaFace) | [MIT](https://github.com/mk-minchul/AdaFace/blob/master/LICENSE) | 2022 | [AdaFaceDemo](creative_apps/AdaFaceDemo) | [convert_adaface.py](conversion_scripts/convert_adaface.py) |

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ You are free to do or not.
   - [Openjourney](#openjourney)
   - [dreamlike-photoreal-2.0](#dreamlike-photoreal-2)
 
+- [**Face Recognition**](#face-recognition)
+  - [AdaFace IR-18](#adaface-ir-18)
+
 - [**3D Face Pose Estimation**](#3d-face-pose-estimation)
   - [3DDFA_V2](#3ddfa_v2)
 
@@ -873,6 +876,16 @@ Pastel Mix - a stylized latent diffusion model.This model is intended to produce
 | Google Drive Link  | Original Model | License | Run on mac |Conversion Script |Year|
 | ------------- | ------------- | ------------- |  ------------- | ------------- | ------------- | 
 | [dreamlike-photoreal-2.0](https://drive.google.com/file/d/1D5RXYE52wyXPq6TdCHM8DIkP4dxHafwt/view?usp=share_link) |[dreamlike-art/dreamlike-photoreal-2.0](https://huggingface.co/dreamlike-art/dreamlike-photoreal-2.0)|[CreativeML OpenRAIL-M](https://huggingface.co/dreamlike-art/dreamlike-photoreal-2.0)|[godly-devotion/MochiDiffusion](https://github.com/godly-devotion/MochiDiffusion)|[godly-devotion/MochiDiffusion](https://github.com/godly-devotion/MochiDiffusion/wiki/How-to-convert-Stable-Diffusion-models-to-Core-ML#requirements) |2023|
+
+# Face Recognition
+
+### AdaFace IR-18
+
+AdaFace — Quality-adaptive face recognition. Outputs 512-dim embedding for face verification and identification.
+
+| Download Link | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| [AdaFace_IR18.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/adaface-v1/AdaFace_IR18.mlpackage.zip) | 48 MB | Image (112×112 face) | 512-dim L2-normalized embedding | [mk-minchul/AdaFace](https://github.com/mk-minchul/AdaFace) | [MIT](https://github.com/mk-minchul/AdaFace/blob/master/LICENSE) | 2022 | [AdaFaceDemo](creative_apps/AdaFaceDemo) | [convert_adaface.py](conversion_scripts/convert_adaface.py) |
 
 # 3D Face Pose Estimation
 

--- a/conversion_scripts/convert_adaface.py
+++ b/conversion_scripts/convert_adaface.py
@@ -1,0 +1,174 @@
+"""
+Convert AdaFace IR-18 face recognition model to CoreML.
+
+Usage:
+    python3 convert_adaface.py
+
+Output:
+    creative_apps/AdaFaceDemo/AdaFaceDemo/AdaFace_IR18.mlpackage
+
+Model: AdaFace (CVPR 2022) via CVLface
+  - Input: 112x112 RGB face image
+  - Output: 512-dim L2-normalized face embedding
+  - License: MIT
+  - Repo: https://github.com/mk-minchul/AdaFace
+"""
+
+import torch
+import torch.nn as nn
+import coremltools as ct
+import os
+import sys
+
+# === iResNet-18 architecture (from CVLface, fvcore dependency removed) ===
+
+class Flatten(nn.Module):
+    def forward(self, x):
+        return x.view(x.size(0), -1)
+
+class BasicBlockIR(nn.Module):
+    def __init__(self, in_channel, depth, stride):
+        super().__init__()
+        if in_channel == depth:
+            self.shortcut_layer = nn.MaxPool2d(1, stride)
+        else:
+            self.shortcut_layer = nn.Sequential(
+                nn.Conv2d(in_channel, depth, (1, 1), stride, bias=False),
+                nn.BatchNorm2d(depth))
+        self.res_layer = nn.Sequential(
+            nn.BatchNorm2d(in_channel),
+            nn.Conv2d(in_channel, depth, (3, 3), (1, 1), 1, bias=False),
+            nn.BatchNorm2d(depth),
+            nn.PReLU(depth),
+            nn.Conv2d(depth, depth, (3, 3), stride, 1, bias=False),
+            nn.BatchNorm2d(depth))
+
+    def forward(self, x):
+        shortcut = self.shortcut_layer(x)
+        res = self.res_layer(x)
+        return res + shortcut
+
+def get_block(in_channel, depth, num_units, stride=2):
+    return [BasicBlockIR(in_channel, depth, stride)] + \
+           [BasicBlockIR(depth, depth, 1) for _ in range(num_units - 1)]
+
+# IR-18 block config
+BLOCKS_IR18 = [
+    (64, 64, 2, 2),    # in_ch, depth, num_units, stride
+    (64, 128, 2, 2),
+    (128, 256, 2, 2),
+    (256, 512, 2, 2),
+]
+
+class Backbone(nn.Module):
+    def __init__(self, input_size=(112, 112), output_dim=512):
+        super().__init__()
+        self.input_layer = nn.Sequential(
+            nn.Conv2d(3, 64, (3, 3), 1, 1, bias=False),
+            nn.BatchNorm2d(64),
+            nn.PReLU(64))
+
+        modules = []
+        for in_ch, depth, num_units, stride in BLOCKS_IR18:
+            modules += get_block(in_ch, depth, num_units, stride)
+        self.body = nn.Sequential(*modules)
+
+        self.output_layer = nn.Sequential(
+            nn.BatchNorm2d(512),
+            nn.Dropout(0.4),
+            Flatten(),
+            nn.Linear(512 * 7 * 7, output_dim),
+            nn.BatchNorm1d(output_dim, affine=False))
+
+    def forward(self, x):
+        x = self.input_layer(x)
+        x = self.body(x)
+        x = self.output_layer(x)
+        return x
+
+class AdaFaceModel(nn.Module):
+    def __init__(self, backbone):
+        super().__init__()
+        self.backbone = backbone
+
+    def forward(self, x):
+        emb = self.backbone(x)
+        emb = nn.functional.normalize(emb, p=2, dim=1)
+        return emb
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Load pretrained weights from HuggingFace cache
+    hf_cache = os.path.expanduser("~/.cache/huggingface/hub/models--minchul--cvlface_adaface_ir18_webface4m")
+    snapshot_dir = None
+    snapshots = os.path.join(hf_cache, "snapshots")
+    if os.path.exists(snapshots):
+        dirs = os.listdir(snapshots)
+        if dirs:
+            snapshot_dir = os.path.join(snapshots, dirs[0])
+
+    if snapshot_dir is None:
+        print("Please download the model first:")
+        print("  python3 -c \"from huggingface_hub import hf_hub_download; hf_hub_download('minchul/cvlface_adaface_ir18_webface4m', 'pretrained_model/model.pt')\"")
+        sys.exit(1)
+
+    weights_path = os.path.join(snapshot_dir, "pretrained_model", "model.pt")
+    print(f"Loading weights from {weights_path}")
+
+    # Build model
+    backbone = Backbone(input_size=(112, 112), output_dim=512)
+    state_dict = torch.load(weights_path, map_location="cpu", weights_only=False)
+
+    # Keys have "net." prefix
+    new_state = {}
+    for k, v in state_dict.items():
+        new_key = k.replace("net.", "backbone.", 1) if k.startswith("net.") else k
+        new_state[new_key] = v
+
+    model = AdaFaceModel(backbone)
+    model.load_state_dict(new_state, strict=False)
+    model.eval()
+
+    # Verify
+    dummy = torch.randn(1, 3, 112, 112)
+    with torch.no_grad():
+        out = model(dummy)
+    print(f"Output shape: {out.shape}, norm: {torch.norm(out, dim=1).item():.4f}")
+
+    # Trace
+    print("Tracing model...")
+    traced = torch.jit.trace(model, dummy)
+
+    # Convert to CoreML
+    print("Converting to CoreML...")
+    mlmodel = ct.convert(
+        traced,
+        inputs=[
+            ct.ImageType(
+                name="face_image",
+                shape=(1, 3, 112, 112),
+                scale=1.0 / (0.5 * 255.0),
+                bias=[-0.5 / 0.5, -0.5 / 0.5, -0.5 / 0.5],
+                color_layout=ct.colorlayout.BGR,
+            )
+        ],
+        outputs=[ct.TensorType(name="embedding")],
+        minimum_deployment_target=ct.target.iOS16,
+    )
+
+    mlmodel.author = "CoreML-Models"
+    mlmodel.short_description = "AdaFace IR-18: Face recognition embedding (512-dim). Input: 112x112 face image."
+    mlmodel.license = "MIT"
+
+    output_path = os.path.join(script_dir, "..", "creative_apps", "AdaFaceDemo", "AdaFaceDemo", "AdaFace_IR18.mlpackage")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    mlmodel.save(output_path)
+    print(f"\nSaved to {output_path}")
+
+    size_mb = sum(os.path.getsize(os.path.join(dp, f))
+                  for dp, _, fns in os.walk(output_path) for f in fns) / 1e6
+    print(f"Model size: {size_mb:.1f} MB")
+
+if __name__ == "__main__":
+    main()

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo.xcodeproj/project.pbxproj
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,347 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000010000000000000001 /* AdaFaceDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000001 /* AdaFaceDemoApp.swift */; };
+		A10000010000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000002 /* ContentView.swift */; };
+		A10000010000000000000003 /* FaceRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000003 /* FaceRecognizer.swift */; };
+		A10000010000000000000004 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000004 /* Assets.xcassets */; };
+		A10000010000000000000006 /* AdaFace_IR18.mlpackage in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000006 /* AdaFace_IR18.mlpackage */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A10000020000000000000001 /* AdaFaceDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaFaceDemoApp.swift; sourceTree = "<group>"; };
+		A10000020000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A10000020000000000000003 /* FaceRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceRecognizer.swift; sourceTree = "<group>"; };
+		A10000020000000000000004 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A10000020000000000000005 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A10000020000000000000006 /* AdaFace_IR18.mlpackage */ = {isa = PBXFileReference; lastKnownFileType = folder.mlpackage; path = AdaFace_IR18.mlpackage; sourceTree = "<group>"; };
+		A10000020000000000000010 /* AdaFaceDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AdaFaceDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A10000030000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A10000040000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				A10000040000000000000002 /* AdaFaceDemo */,
+				A10000040000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A10000040000000000000002 /* AdaFaceDemo */ = {
+			isa = PBXGroup;
+			children = (
+				A10000020000000000000001 /* AdaFaceDemoApp.swift */,
+				A10000020000000000000002 /* ContentView.swift */,
+				A10000020000000000000003 /* FaceRecognizer.swift */,
+				A10000020000000000000006 /* AdaFace_IR18.mlpackage */,
+				A10000020000000000000004 /* Assets.xcassets */,
+				A10000020000000000000005 /* Info.plist */,
+			);
+			path = AdaFaceDemo;
+			sourceTree = "<group>";
+		};
+		A10000040000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A10000020000000000000010 /* AdaFaceDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A10000050000000000000001 /* AdaFaceDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000070000000000000001 /* Build configuration list for PBXNativeTarget "AdaFaceDemo" */;
+			buildPhases = (
+				A10000060000000000000001 /* Sources */,
+				A10000030000000000000001 /* Frameworks */,
+				A10000060000000000000002 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AdaFaceDemo;
+			productName = AdaFaceDemo;
+			productReference = A10000020000000000000010 /* AdaFaceDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A10000080000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					A10000050000000000000001 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = A10000070000000000000003 /* Build configuration list for PBXProject "AdaFaceDemo" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A10000040000000000000001;
+			productRefGroup = A10000040000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A10000050000000000000001 /* AdaFaceDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A10000060000000000000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000010000000000000004 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A10000060000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000010000000000000006 /* AdaFace_IR18.mlpackage in Sources */,
+				A10000010000000000000001 /* AdaFaceDemoApp.swift in Sources */,
+				A10000010000000000000002 /* ContentView.swift in Sources */,
+				A10000010000000000000003 /* FaceRecognizer.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A10000090000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A10000090000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A10000090000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MFN25KNUGJ;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = AdaFaceDemo/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app needs camera access for face recognition.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.coreml-models.adafacedemo";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A10000090000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MFN25KNUGJ;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = AdaFaceDemo/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app needs camera access for face recognition.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.coreml-models.adafacedemo";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A10000070000000000000001 /* Build configuration list for PBXNativeTarget "AdaFaceDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000090000000000000003 /* Debug */,
+				A10000090000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A10000070000000000000003 /* Build configuration list for PBXProject "AdaFaceDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000090000000000000001 /* Debug */,
+				A10000090000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A10000080000000000000001 /* Project object */;
+}

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo/AdaFaceDemoApp.swift
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo/AdaFaceDemoApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AdaFaceDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo/Assets.xcassets/Contents.json
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo/ContentView.swift
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo/ContentView.swift
@@ -1,0 +1,594 @@
+import SwiftUI
+import PhotosUI
+import AVFoundation
+
+struct ContentView: View {
+    @StateObject private var recognizer = FaceRecognizer()
+
+    var body: some View {
+        TabView {
+            RegisterTab(recognizer: recognizer)
+                .tabItem { Label("Register", systemImage: "person.badge.plus") }
+            CompareTab(recognizer: recognizer)
+                .tabItem { Label("Compare", systemImage: "person.2.circle") }
+            CameraTab(recognizer: recognizer)
+                .tabItem { Label("Live", systemImage: "camera") }
+        }
+    }
+}
+
+// MARK: - Register Tab
+
+struct RegisterTab: View {
+    @ObservedObject var recognizer: FaceRecognizer
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var selectedImage: UIImage?
+    @State private var name = ""
+    @State private var registering = false
+    @State private var message = ""
+    @State private var showCamera = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                HStack(spacing: 12) {
+                    // Face image preview
+                    Group {
+                        if let img = selectedImage {
+                            Image(uiImage: img)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 80, height: 80)
+                                .clipShape(Circle())
+                        } else {
+                            ZStack {
+                                Circle().fill(.quaternary).frame(width: 80, height: 80)
+                                Image(systemName: "person.crop.circle.badge.plus")
+                                    .font(.title)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    .onTapGesture { showCamera = true }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        TextField("Name", text: $name)
+                            .textFieldStyle(.roundedBorder)
+
+                        HStack(spacing: 8) {
+                            Button {
+                                registerFace()
+                            } label: {
+                                HStack {
+                                    if registering {
+                                        ProgressView().controlSize(.small)
+                                    }
+                                    Text("Register")
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(selectedImage == nil || name.isEmpty || registering)
+
+                            PhotosPicker(selection: $selectedItem, matching: .images) {
+                                Image(systemName: "photo")
+                                    .frame(width: 36, height: 36)
+                            }
+                            .buttonStyle(.bordered)
+
+                            Button {
+                                showCamera = true
+                            } label: {
+                                Image(systemName: "camera")
+                                    .frame(width: 36, height: 36)
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+                }
+                .padding(.horizontal)
+
+                if !message.isEmpty {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundColor(message.contains("Error") ? .red : .green)
+                        .padding(.horizontal)
+                }
+
+                List {
+                    ForEach(recognizer.registered) { face in
+                        HStack(spacing: 12) {
+                            if let thumb = face.thumbnail {
+                                Image(uiImage: thumb)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 44, height: 44)
+                                    .clipShape(Circle())
+                            } else {
+                                Image(systemName: "person.circle.fill")
+                                    .font(.title2)
+                                    .foregroundColor(.blue)
+                                    .frame(width: 44, height: 44)
+                            }
+                            VStack(alignment: .leading) {
+                                Text(face.name).font(.body).bold()
+                                Text(face.date, style: .date)
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    .onDelete { offsets in
+                        recognizer.deleteRegistered(at: offsets)
+                    }
+
+                    if recognizer.registered.isEmpty {
+                        Text("No faces registered yet")
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Face Registration")
+            .onTapGesture {
+                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                                to: nil, from: nil, for: nil)
+            }
+            .sheet(isPresented: $showCamera) {
+                CameraCaptureView { image in
+                    selectedImage = image
+                    showCamera = false
+                }
+            }
+        }
+        .onChange(of: selectedItem) { _ in loadImage() }
+    }
+
+    private func loadImage() {
+        guard let item = selectedItem else { return }
+        Task {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let img = UIImage(data: data) {
+                selectedImage = img
+            }
+        }
+    }
+
+    private func registerFace() {
+        guard let img = selectedImage else { return }
+        registering = true
+        message = ""
+        Task {
+            let success = await recognizer.register(name: name, image: img)
+            await MainActor.run {
+                if success {
+                    message = "Registered \(name)"
+                    name = ""
+                    selectedImage = nil
+                    selectedItem = nil
+                } else {
+                    message = "Error: No face detected in image"
+                }
+                registering = false
+            }
+        }
+    }
+}
+
+// MARK: - Compare Tab
+
+struct CompareEntry: Identifiable {
+    let id = UUID()
+    let thumbnail: UIImage?
+    let embedding: [Float]
+    var similarity: Float
+}
+
+struct CompareTab: View {
+    @ObservedObject var recognizer: FaceRecognizer
+    @State private var selectedRefIndex = 0
+    @State private var entries: [CompareEntry] = []
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var processing = false
+
+    private var reference: FaceEmbedding? {
+        guard !recognizer.registered.isEmpty,
+              selectedRefIndex < recognizer.registered.count else { return nil }
+        return recognizer.registered[selectedRefIndex]
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                if recognizer.registered.isEmpty {
+                    Spacer()
+                    Text("Register a face first").foregroundColor(.secondary)
+                    Spacer()
+                } else {
+                    // Reference selector
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 12) {
+                            ForEach(Array(recognizer.registered.enumerated()), id: \.element.id) { i, face in
+                                VStack(spacing: 4) {
+                                    if let thumb = face.thumbnail {
+                                        Image(uiImage: thumb)
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 48, height: 48)
+                                            .clipShape(Circle())
+                                            .overlay(Circle().stroke(i == selectedRefIndex ? Color.blue : Color.clear, lineWidth: 3))
+                                    } else {
+                                        Circle().fill(.quaternary).frame(width: 48, height: 48)
+                                            .overlay(Circle().stroke(i == selectedRefIndex ? Color.blue : Color.clear, lineWidth: 3))
+                                    }
+                                    Text(face.name).font(.caption2).lineLimit(1)
+                                }
+                                .onTapGesture {
+                                    selectedRefIndex = i
+                                    recalcSimilarities()
+                                }
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+                    .padding(.vertical, 8)
+
+                    // Radial comparison view
+                    GeometryReader { geo in
+                        let center = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
+                        let maxRadius = min(geo.size.width, geo.size.height) / 2 - 40
+
+                        ZStack {
+                            // Threshold circles
+                            ForEach([0.6, 0.4, 0.2], id: \.self) { threshold in
+                                let r = maxRadius * CGFloat(1.0 - threshold)
+                                Circle()
+                                    .stroke(threshold == 0.6 ? Color.green.opacity(0.3) : Color.gray.opacity(0.15), lineWidth: 1)
+                                    .frame(width: r * 2, height: r * 2)
+                                    .position(center)
+                            }
+
+                            // "Same person" zone label
+                            Text("Same Person")
+                                .font(.caption2)
+                                .foregroundColor(.green.opacity(0.5))
+                                .position(x: center.x, y: center.y - maxRadius * 0.4 + 14)
+
+                            // 60% label
+                            Text("60%")
+                                .font(.caption2)
+                                .foregroundColor(.green.opacity(0.4))
+                                .position(x: center.x + maxRadius * 0.4 + 16, y: center.y)
+
+                            // Reference face at center
+                            if let ref = reference, let thumb = ref.thumbnail {
+                                Image(uiImage: thumb)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 56, height: 56)
+                                    .clipShape(Circle())
+                                    .overlay(Circle().stroke(Color.blue, lineWidth: 3))
+                                    .position(center)
+                            } else {
+                                Circle().fill(.blue.opacity(0.3)).frame(width: 56, height: 56)
+                                    .overlay(Text(reference?.name.prefix(1) ?? "?").font(.title2).foregroundColor(.white))
+                                    .position(center)
+                            }
+
+                            // Comparison entries
+                            ForEach(Array(entries.enumerated()), id: \.element.id) { i, entry in
+                                let angle = entryAngle(index: i, total: entries.count)
+                                let dist = maxRadius * CGFloat(1.0 - max(0, entry.similarity))
+                                let x = center.x + dist * cos(angle)
+                                let y = center.y + dist * sin(angle)
+                                let isMatch = entry.similarity >= 0.6
+
+                                VStack(spacing: 2) {
+                                    if let thumb = entry.thumbnail {
+                                        Image(uiImage: thumb)
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 40, height: 40)
+                                            .clipShape(Circle())
+                                            .overlay(Circle().stroke(isMatch ? Color.green : Color.red, lineWidth: 2))
+                                    } else {
+                                        Circle().fill(.gray).frame(width: 40, height: 40)
+                                    }
+                                    Text(String(format: "%.0f%%", entry.similarity * 100))
+                                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                                        .foregroundColor(isMatch ? .green : .red)
+                                }
+                                .position(x: x, y: y)
+                            }
+                        }
+                    }
+
+                    // Bottom bar
+                    HStack {
+                        PhotosPicker(selection: $selectedItem, matching: .images) {
+                            Label("Add Photo", systemImage: "plus.circle.fill")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(reference == nil || processing)
+
+                        if processing {
+                            ProgressView().controlSize(.small)
+                        }
+
+                        Spacer()
+
+                        if !entries.isEmpty {
+                            Button("Clear") {
+                                entries.removeAll()
+                            }
+                            .foregroundColor(.red)
+                        }
+                    }
+                    .padding()
+                }
+            }
+            .navigationTitle("Compare")
+            .onChange(of: selectedItem) { _ in addCompareImage() }
+        }
+    }
+
+    private func entryAngle(index: Int, total: Int) -> CGFloat {
+        guard total > 0 else { return 0 }
+        let start: CGFloat = -.pi / 2
+        return start + CGFloat(index) * (2 * .pi / CGFloat(max(total, 1)))
+    }
+
+    private func addCompareImage() {
+        guard let item = selectedItem, let ref = reference else { return }
+        processing = true
+        Task {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let img = UIImage(data: data),
+               let result = await recognizer.extractEmbedding(image: img) {
+                let sim = recognizer.similarity(ref.embedding, result.embedding)
+                await MainActor.run {
+                    entries.append(CompareEntry(thumbnail: result.thumbnail, embedding: result.embedding, similarity: sim))
+                }
+            }
+            await MainActor.run {
+                processing = false
+                selectedItem = nil
+            }
+        }
+    }
+
+    private func recalcSimilarities() {
+        guard let ref = reference else { return }
+        for i in entries.indices {
+            entries[i].similarity = recognizer.similarity(ref.embedding, entries[i].embedding)
+        }
+    }
+}
+
+// MARK: - Camera Capture for Registration
+
+struct CameraCaptureView: UIViewControllerRepresentable {
+    let onCapture: (UIImage) -> Void
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.cameraDevice = .front
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ vc: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onCapture: onCapture) }
+
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onCapture: (UIImage) -> Void
+        init(onCapture: @escaping (UIImage) -> Void) { self.onCapture = onCapture }
+
+        func imagePickerController(_ picker: UIImagePickerController,
+                                   didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                onCapture(image)
+            }
+            picker.dismiss(animated: true)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
+        }
+    }
+}
+
+// MARK: - Camera Tab
+
+struct CameraTab: View {
+    @ObservedObject var recognizer: FaceRecognizer
+
+    var body: some View {
+        ZStack {
+            CameraViewWrapper(recognizer: recognizer)
+                .ignoresSafeArea()
+
+            if recognizer.registered.isEmpty {
+                VStack {
+                    Spacer()
+                    Text("Register faces first to start recognition")
+                        .font(.callout)
+                        .padding()
+                        .background(.ultraThinMaterial)
+                        .cornerRadius(10)
+                        .padding(.bottom, 100)
+                }
+            }
+        }
+    }
+}
+
+struct CameraViewWrapper: UIViewControllerRepresentable {
+    let recognizer: FaceRecognizer
+    func makeUIViewController(context: Context) -> CameraVC { CameraVC(recognizer: recognizer) }
+    func updateUIViewController(_ vc: CameraVC, context: Context) {}
+}
+
+// MARK: - Camera VC
+
+class CameraVC: UIViewController, AVCaptureVideoDataOutputSampleBufferDelegate {
+    private let recognizer: FaceRecognizer
+    private let session = AVCaptureSession()
+    private let sessionQueue = DispatchQueue(label: "session")
+    private let inferenceQueue = DispatchQueue(label: "inference")
+    private var previewLayer: AVCaptureVideoPreviewLayer!
+    private var overlayLayer = CALayer()
+    private var isProcessing = false
+    private var smoothedLatency: Double = 0
+
+    init(recognizer: FaceRecognizer) {
+        self.recognizer = recognizer
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupCamera()
+        setupOverlay()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+        overlayLayer.frame = view.bounds
+    }
+
+    private func setupCamera() {
+        previewLayer = AVCaptureVideoPreviewLayer(session: session)
+        previewLayer.videoGravity = .resizeAspectFill
+        view.layer.addSublayer(previewLayer)
+
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            session.beginConfiguration()
+            session.sessionPreset = .high
+
+            guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front),
+                  let input = try? AVCaptureDeviceInput(device: device),
+                  session.canAddInput(input) else { return }
+            session.addInput(input)
+
+            let output = AVCaptureVideoDataOutput()
+            output.alwaysDiscardsLateVideoFrames = true
+            output.setSampleBufferDelegate(self, queue: inferenceQueue)
+            if session.canAddOutput(output) {
+                session.addOutput(output)
+            }
+            if let conn = output.connection(with: .video) {
+                conn.videoOrientation = .portrait
+                conn.isVideoMirrored = true
+            }
+            session.commitConfiguration()
+            session.startRunning()
+        }
+    }
+
+    private func setupOverlay() {
+        view.layer.addSublayer(overlayLayer)
+    }
+
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        guard !isProcessing else { return }
+        isProcessing = true
+
+        guard let pb = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+            isProcessing = false
+            return
+        }
+
+        let start = CACurrentMediaTime()
+        let results = recognizer.recognize(pixelBuffer: pb)
+        let latency = (CACurrentMediaTime() - start) * 1000
+        smoothedLatency = smoothedLatency * 0.8 + latency * 0.2
+
+        let bufW = CGFloat(CVPixelBufferGetWidth(pb))
+        let bufH = CGFloat(CVPixelBufferGetHeight(pb))
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.drawResults(results, bufferSize: CGSize(width: bufW, height: bufH))
+            self.isProcessing = false
+        }
+    }
+
+    private func drawResults(_ results: [RecognitionResult], bufferSize: CGSize) {
+        overlayLayer.sublayers?.forEach { $0.removeFromSuperlayer() }
+
+        let viewSize = view.bounds.size
+        let scale = max(viewSize.width / bufferSize.width, viewSize.height / bufferSize.height)
+        let scaledW = bufferSize.width * scale
+        let scaledH = bufferSize.height * scale
+        let offsetX = (viewSize.width - scaledW) / 2
+        let offsetY = (viewSize.height - scaledH) / 2
+
+        for r in results {
+            let rx = r.faceRect.origin.x * scaledW + offsetX
+            let ry = (1.0 - r.faceRect.origin.y - r.faceRect.height) * scaledH + offsetY
+            let rw = r.faceRect.width * scaledW
+            let rh = r.faceRect.height * scaledH
+            let faceFrame = CGRect(x: rx, y: ry, width: rw, height: rh)
+
+            let matched = r.match != nil && r.similarity > 0.3
+            let borderColor = matched ? UIColor.systemGreen : UIColor.systemRed
+
+            let rectLayer = CAShapeLayer()
+            rectLayer.path = UIBezierPath(roundedRect: faceFrame, cornerRadius: 8).cgPath
+            rectLayer.strokeColor = borderColor.cgColor
+            rectLayer.fillColor = UIColor.clear.cgColor
+            rectLayer.lineWidth = 3
+            overlayLayer.addSublayer(rectLayer)
+
+            let label = CATextLayer()
+            let nameText = r.match?.name ?? "Unknown"
+            let simText = String(format: "%.0f%%", r.similarity * 100)
+            label.string = "\(nameText)  \(simText)"
+            label.fontSize = 16
+            label.font = UIFont.boldSystemFont(ofSize: 16)
+            label.foregroundColor = UIColor.white.cgColor
+            label.backgroundColor = borderColor.withAlphaComponent(0.7).cgColor
+            label.cornerRadius = 6
+            label.contentsScale = UIScreen.main.scale
+            label.alignmentMode = .center
+            label.frame = CGRect(x: rx, y: ry - 30, width: rw, height: 26)
+            overlayLayer.addSublayer(label)
+
+            let barBg = CALayer()
+            barBg.frame = CGRect(x: rx, y: ry + rh + 4, width: rw, height: 6)
+            barBg.backgroundColor = UIColor.darkGray.cgColor
+            barBg.cornerRadius = 3
+            overlayLayer.addSublayer(barBg)
+
+            let barFill = CALayer()
+            let fillWidth = rw * CGFloat(max(0, min(1, r.similarity)))
+            barFill.frame = CGRect(x: rx, y: ry + rh + 4, width: fillWidth, height: 6)
+            barFill.backgroundColor = borderColor.cgColor
+            barFill.cornerRadius = 3
+            overlayLayer.addSublayer(barFill)
+        }
+
+        let statsLayer = CATextLayer()
+        statsLayer.string = String(format: "  %.0f ms", smoothedLatency)
+        statsLayer.fontSize = 14
+        statsLayer.foregroundColor = UIColor.white.cgColor
+        statsLayer.backgroundColor = UIColor.black.withAlphaComponent(0.5).cgColor
+        statsLayer.cornerRadius = 6
+        statsLayer.contentsScale = UIScreen.main.scale
+        statsLayer.frame = CGRect(x: 16, y: view.safeAreaInsets.top + 8, width: 100, height: 30)
+        overlayLayer.addSublayer(statsLayer)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        sessionQueue.async { [weak self] in
+            self?.session.stopRunning()
+        }
+    }
+}

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo/ContentView.swift
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo/ContentView.swift
@@ -236,28 +236,32 @@ struct CompareTab: View {
                     GeometryReader { geo in
                         let center = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
                         let maxRadius = min(geo.size.width, geo.size.height) / 2 - 40
+                        let positions = resolvedPositions(center: center, maxRadius: maxRadius)
+
+                        let sameZoneR = maxRadius * 0.6  // green circle at 60% of radius
 
                         ZStack {
-                            // Threshold circles
-                            ForEach([0.6, 0.4, 0.2], id: \.self) { threshold in
-                                let r = maxRadius * CGFloat(1.0 - threshold)
-                                Circle()
-                                    .stroke(threshold == 0.6 ? Color.green.opacity(0.3) : Color.gray.opacity(0.15), lineWidth: 1)
-                                    .frame(width: r * 2, height: r * 2)
-                                    .position(center)
-                            }
+                            // Same Person zone circle
+                            Circle()
+                                .stroke(Color.green.opacity(0.3), lineWidth: 2)
+                                .frame(width: sameZoneR * 2, height: sameZoneR * 2)
+                                .position(center)
 
-                            // "Same person" zone label
+                            // Outer guide circles
+                            Circle()
+                                .stroke(Color.gray.opacity(0.1), lineWidth: 1)
+                                .frame(width: maxRadius * 1.5, height: maxRadius * 1.5)
+                                .position(center)
+
                             Text("Same Person")
                                 .font(.caption2)
                                 .foregroundColor(.green.opacity(0.5))
-                                .position(x: center.x, y: center.y - maxRadius * 0.4 + 14)
+                                .position(x: center.x, y: center.y - sameZoneR + 14)
 
-                            // 60% label
                             Text("60%")
                                 .font(.caption2)
                                 .foregroundColor(.green.opacity(0.4))
-                                .position(x: center.x + maxRadius * 0.4 + 16, y: center.y)
+                                .position(x: center.x + sameZoneR + 16, y: center.y)
 
                             // Reference face at center
                             if let ref = reference, let thumb = ref.thumbnail {
@@ -274,12 +278,9 @@ struct CompareTab: View {
                                     .position(center)
                             }
 
-                            // Comparison entries
-                            ForEach(Array(entries.enumerated()), id: \.element.id) { i, entry in
-                                let angle = entryAngle(index: i, total: entries.count)
-                                let dist = maxRadius * CGFloat(1.0 - max(0, entry.similarity))
-                                let x = center.x + dist * cos(angle)
-                                let y = center.y + dist * sin(angle)
+                            // Comparison entries at resolved positions
+                            ForEach(Array(positions.enumerated()), id: \.offset) { i, pos in
+                                let entry = entries[i]
                                 let isMatch = entry.similarity >= 0.6
 
                                 VStack(spacing: 2) {
@@ -297,7 +298,7 @@ struct CompareTab: View {
                                         .font(.system(size: 10, weight: .bold, design: .monospaced))
                                         .foregroundColor(isMatch ? .green : .red)
                                 }
-                                .position(x: x, y: y)
+                                .position(x: pos.x, y: pos.y)
                             }
                         }
                     }
@@ -331,10 +332,105 @@ struct CompareTab: View {
         }
     }
 
-    private func entryAngle(index: Int, total: Int) -> CGFloat {
-        guard total > 0 else { return 0 }
-        let start: CGFloat = -.pi / 2
-        return start + CGFloat(index) * (2 * .pi / CGFloat(max(total, 1)))
+    // Place entries on radial layout with two zones:
+    //   Same Person zone (>=60%): close to center, distance by similarity within zone
+    //   Others (<60%): outside the 60% circle, distance by similarity
+    // Then push apart to resolve overlaps without crossing zone boundaries.
+    private func resolvedPositions(center: CGPoint, maxRadius: CGFloat) -> [CGPoint] {
+        guard !entries.isEmpty else { return [] }
+
+        let itemR: CGFloat = 26
+        let refR: CGFloat = 34
+        let gap: CGFloat = 6
+
+        // Must match the green circle drawn in the view: maxRadius * 0.6
+        let sameZoneR = maxRadius * 0.6
+        let innerMin = refR + itemR + gap         // ~66pt from center
+        let innerMax = sameZoneR - gap            // stay inside green circle
+        let outerMin = sameZoneR + gap            // stay outside green circle
+
+        var pts: [CGPoint] = entries.enumerated().map { i, entry in
+            let angle = -.pi / 2 + CGFloat(i) * (2 * .pi / CGFloat(entries.count))
+            let sim = CGFloat(max(0, entry.similarity))
+            let dist: CGFloat
+
+            if sim >= 0.6 {
+                // Inside zone: higher sim = closer to center
+                // Map sim [0.6..1] → dist [innerMax..innerMin]
+                let t = (sim - 0.6) / 0.4
+                dist = innerMax - t * (innerMax - innerMin)
+            } else {
+                // Outside zone: lower sim = farther from center
+                // Map sim [0..0.6) → dist [maxRadius..outerMin]
+                let t = sim / 0.6
+                dist = maxRadius - t * (maxRadius - outerMin)
+            }
+
+            return CGPoint(x: center.x + dist * cos(angle),
+                           y: center.y + dist * sin(angle))
+        }
+
+        // Push-apart iterations
+        let minDist = itemR * 2 + gap
+        for _ in 0..<50 {
+            var moved = false
+
+            // 1. Push entries away from each other
+            for i in 0..<pts.count {
+                for j in (i + 1)..<pts.count {
+                    let dx = pts[j].x - pts[i].x
+                    let dy = pts[j].y - pts[i].y
+                    let d = hypot(dx, dy)
+                    if d < minDist && d > 0.1 {
+                        let push = (minDist - d) / 2 + 1
+                        let nx = dx / d
+                        let ny = dy / d
+                        pts[i].x -= nx * push
+                        pts[i].y -= ny * push
+                        pts[j].x += nx * push
+                        pts[j].y += ny * push
+                        moved = true
+                    }
+                }
+            }
+
+            // 2. Enforce constraints (after push, clamp back to valid zones)
+            for i in 0..<pts.count {
+                let sim = CGFloat(entries[i].similarity)
+                let isInner = sim >= 0.6
+                var dc = hypot(pts[i].x - center.x, pts[i].y - center.y)
+
+                // Always keep away from center ref
+                if dc < innerMin {
+                    if dc < 0.1 { dc = 0.1 }
+                    let s = innerMin / dc
+                    pts[i].x = center.x + (pts[i].x - center.x) * s
+                    pts[i].y = center.y + (pts[i].y - center.y) * s
+                    moved = true
+                    dc = innerMin
+                }
+
+                // Inner zone: keep inside threshold circle
+                if isInner && dc > innerMax {
+                    let s = innerMax / dc
+                    pts[i].x = center.x + (pts[i].x - center.x) * s
+                    pts[i].y = center.y + (pts[i].y - center.y) * s
+                    moved = true
+                }
+
+                // Outer zone: keep outside threshold circle
+                if !isInner && dc < outerMin {
+                    let s = outerMin / dc
+                    pts[i].x = center.x + (pts[i].x - center.x) * s
+                    pts[i].y = center.y + (pts[i].y - center.y) * s
+                    moved = true
+                }
+            }
+
+            if !moved { break }
+        }
+
+        return pts
     }
 
     private func addCompareImage() {

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo/FaceRecognizer.swift
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo/FaceRecognizer.swift
@@ -1,0 +1,431 @@
+import CoreML
+import Vision
+import UIKit
+
+struct FaceEmbedding: Identifiable, Codable {
+    let id: UUID
+    let name: String
+    let embedding: [Float]
+    let date: Date
+    let thumbnailData: Data?
+
+    init(name: String, embedding: [Float], thumbnail: UIImage?) {
+        self.id = UUID()
+        self.name = name
+        self.embedding = embedding
+        self.date = Date()
+        self.thumbnailData = thumbnail?.jpegData(compressionQuality: 0.6)
+    }
+
+    var thumbnail: UIImage? {
+        guard let data = thumbnailData else { return nil }
+        return UIImage(data: data)
+    }
+}
+
+struct RecognitionResult {
+    let faceRect: CGRect
+    let embedding: [Float]
+    let match: FaceEmbedding?
+    let similarity: Float
+}
+
+class FaceRecognizer: ObservableObject {
+    private var mlModel: MLModel?
+    private let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+    @Published var isReady = false
+    @Published var registered: [FaceEmbedding] = []
+
+    // Standard 5-point alignment template for 112x112 (from insightface/ArcFace)
+    private static let alignDst: [(CGFloat, CGFloat)] = [
+        (38.2946, 51.6963),  // left eye
+        (73.5318, 51.5014),  // right eye
+        (56.0252, 71.7366),  // nose tip
+        (41.5493, 92.3655),  // left mouth
+        (70.7299, 92.2041),  // right mouth
+    ]
+
+    private static let storeKey = "registered_faces"
+
+    init() {
+        loadModel()
+        loadRegistered()
+    }
+
+    private func loadModel() {
+        guard let resourcePath = Bundle.main.resourcePath else { return }
+        let fm = FileManager.default
+        guard let items = try? fm.contentsOfDirectory(atPath: resourcePath) else { return }
+        for item in items where item.hasSuffix(".mlmodelc") {
+            let url = URL(fileURLWithPath: (resourcePath as NSString).appendingPathComponent(item))
+            let config = MLModelConfiguration()
+            config.computeUnits = .all
+            if let model = try? MLModel(contentsOf: url, configuration: config) {
+                self.mlModel = model
+                DispatchQueue.main.async { self.isReady = true }
+                return
+            }
+        }
+    }
+
+    // MARK: - Registration
+
+    func register(name: String, image: UIImage) async -> Bool {
+        let fixed = image.normalizedOrientation()
+        guard let cgImage = fixed.cgImage else { return false }
+        let results = await detectAndAlign(cgImage: cgImage)
+        guard let first = results.first else { return false }
+        guard let emb = predict(pixelBuffer: first.alignedBuffer) else { return false }
+
+        let thumb = createThumbnail(from: fixed, faceRect: first.rect)
+        let face = FaceEmbedding(name: name, embedding: emb, thumbnail: thumb)
+        await MainActor.run {
+            registered.append(face)
+            saveRegistered()
+        }
+        return true
+    }
+
+    private func createThumbnail(from image: UIImage, faceRect: CGRect) -> UIImage? {
+        guard let cgImage = image.cgImage else { return nil }
+        let w = CGFloat(cgImage.width)
+        let h = CGFloat(cgImage.height)
+        let margin: CGFloat = 0.3
+        let fx = faceRect.origin.x * w
+        let fy = (1.0 - faceRect.origin.y - faceRect.height) * h
+        let fw = faceRect.width * w
+        let fh = faceRect.height * h
+        let size = max(fw, fh) * (1 + margin)
+        let cx = fx + fw / 2
+        let cy = fy + fh / 2
+        let cropRect = CGRect(x: cx - size / 2, y: cy - size / 2, width: size, height: size)
+            .intersection(CGRect(x: 0, y: 0, width: w, height: h))
+        guard let cropped = cgImage.cropping(to: cropRect) else { return nil }
+        let thumbSize: CGFloat = 100
+        UIGraphicsBeginImageContextWithOptions(CGSize(width: thumbSize, height: thumbSize), false, 1)
+        UIImage(cgImage: cropped).draw(in: CGRect(x: 0, y: 0, width: thumbSize, height: thumbSize))
+        let thumb = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return thumb
+    }
+
+    func deleteRegistered(at offsets: IndexSet) {
+        registered.remove(atOffsets: offsets)
+        saveRegistered()
+    }
+
+    private func saveRegistered() {
+        if let data = try? JSONEncoder().encode(registered) {
+            UserDefaults.standard.set(data, forKey: Self.storeKey)
+        }
+    }
+
+    private func loadRegistered() {
+        if let data = UserDefaults.standard.data(forKey: Self.storeKey),
+           let faces = try? JSONDecoder().decode([FaceEmbedding].self, from: data) {
+            registered = faces
+        }
+    }
+
+    // MARK: - Embedding extraction (for Compare tab)
+
+    func extractEmbedding(image: UIImage) async -> (embedding: [Float], thumbnail: UIImage?)? {
+        let fixed = image.normalizedOrientation()
+        guard let cgImage = fixed.cgImage else { return nil }
+        let results = await detectAndAlign(cgImage: cgImage)
+        guard let first = results.first else { return nil }
+        guard let emb = predict(pixelBuffer: first.alignedBuffer) else { return nil }
+        let thumb = createThumbnail(from: fixed, faceRect: first.rect)
+        return (emb, thumb)
+    }
+
+    func similarity(_ a: [Float], _ b: [Float]) -> Float {
+        cosineSimilarity(a, b)
+    }
+
+    // MARK: - Recognition (Camera)
+
+    func recognize(pixelBuffer: CVPixelBuffer) -> [RecognitionResult] {
+        let faces = detectAndAlignSync(pixelBuffer: pixelBuffer)
+        return faces.compactMap { face in
+            guard let emb = predict(pixelBuffer: face.alignedBuffer) else { return nil }
+            let (match, sim) = findBestMatch(for: emb)
+            return RecognitionResult(faceRect: face.rect, embedding: emb, match: match, similarity: sim)
+        }
+    }
+
+    // MARK: - Face detection + alignment
+
+    private struct AlignedFace {
+        let rect: CGRect
+        let alignedBuffer: CVPixelBuffer
+    }
+
+    private func detectAndAlign(cgImage: CGImage) async -> [AlignedFace] {
+        let observations = await detectFaceLandmarks(cgImage: cgImage)
+        let w = CGFloat(cgImage.width)
+        let h = CGFloat(cgImage.height)
+        let ciImage = CIImage(cgImage: cgImage)
+        return observations.compactMap { obs in
+            guard let lm = obs.landmarks else { return nil }
+            guard let aligned = alignFace(ciImage: ciImage, observation: obs, landmarks: lm,
+                                           imageWidth: w, imageHeight: h) else { return nil }
+            return AlignedFace(rect: obs.boundingBox, alignedBuffer: aligned)
+        }
+    }
+
+    private func detectAndAlignSync(pixelBuffer: CVPixelBuffer) -> [AlignedFace] {
+        let observations = detectFaceLandmarksSync(pixelBuffer: pixelBuffer)
+        let w = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
+        let h = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        return observations.compactMap { obs in
+            guard let lm = obs.landmarks else { return nil }
+            guard let aligned = alignFace(ciImage: ciImage, observation: obs, landmarks: lm,
+                                           imageWidth: w, imageHeight: h) else { return nil }
+            return AlignedFace(rect: obs.boundingBox, alignedBuffer: aligned)
+        }
+    }
+
+    private func detectFaceLandmarks(cgImage: CGImage) async -> [VNFaceObservation] {
+        await withCheckedContinuation { cont in
+            let req = VNDetectFaceLandmarksRequest { request, _ in
+                cont.resume(returning: (request.results as? [VNFaceObservation]) ?? [])
+            }
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            try? handler.perform([req])
+        }
+    }
+
+    private func detectFaceLandmarksSync(pixelBuffer: CVPixelBuffer) -> [VNFaceObservation] {
+        var results: [VNFaceObservation] = []
+        let req = VNDetectFaceLandmarksRequest { request, _ in
+            results = (request.results as? [VNFaceObservation]) ?? []
+        }
+        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:])
+        try? handler.perform([req])
+        return results
+    }
+
+    // MARK: - Face alignment via affine transform
+
+    private func alignFace(ciImage: CIImage, observation: VNFaceObservation,
+                            landmarks: VNFaceLandmarks2D,
+                            imageWidth: CGFloat, imageHeight: CGFloat) -> CVPixelBuffer? {
+        // Extract 5 key points in pixel coordinates
+        guard let srcPoints = extract5Points(observation: observation, landmarks: landmarks,
+                                              imageWidth: imageWidth, imageHeight: imageHeight) else { return nil }
+
+        let dstPoints = Self.alignDst
+
+        // Compute affine transform from src → dst (112x112)
+        guard let transform = estimateAffineTransform(src: srcPoints, dst: dstPoints) else { return nil }
+
+        // Apply transform using CIImage
+        let ciTransform = CGAffineTransform(a: transform[0], b: transform[3],
+                                             c: transform[1], d: transform[4],
+                                             tx: transform[2], ty: transform[5])
+        let transformed = ciImage.transformed(by: ciTransform)
+
+        // Render to 112x112 pixel buffer
+        var out: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, 112, 112, kCVPixelFormatType_32BGRA, nil, &out)
+        guard let outBuffer = out else { return nil }
+        ciContext.render(transformed, to: outBuffer,
+                         bounds: CGRect(x: 0, y: 0, width: 112, height: 112),
+                         colorSpace: CGColorSpaceCreateDeviceRGB())
+        return outBuffer
+    }
+
+    private func extract5Points(observation: VNFaceObservation, landmarks: VNFaceLandmarks2D,
+                                 imageWidth: CGFloat, imageHeight: CGFloat) -> [(CGFloat, CGFloat)]? {
+        // Get landmark regions
+        guard let leftEye = landmarks.leftEye,
+              let rightEye = landmarks.rightEye,
+              let nose = landmarks.noseCrest,
+              let outerLips = landmarks.outerLips else { return nil }
+
+        let bbox = observation.boundingBox
+
+        // Helper: convert normalized landmark point to pixel coordinates
+        // VNFaceLandmarks points are normalized relative to the face bounding box
+        // Bounding box is in Vision coords (origin bottom-left)
+        func toPixel(_ pts: [CGPoint]) -> CGPoint {
+            let avg = pts.reduce(CGPoint.zero) { CGPoint(x: $0.x + $1.x, y: $0.y + $1.y) }
+            let n = CGFloat(pts.count)
+            let normX = avg.x / n
+            let normY = avg.y / n
+            // Convert from face-relative normalized to image pixel coords
+            // CIImage uses bottom-left origin (same as Vision)
+            let px = (bbox.origin.x + normX * bbox.width) * imageWidth
+            let py = (bbox.origin.y + normY * bbox.height) * imageHeight
+            return CGPoint(x: px, y: py)
+        }
+
+        let leftEyeCenter = toPixel(leftEye.normalizedPoints.map { $0 })
+        let rightEyeCenter = toPixel(rightEye.normalizedPoints.map { $0 })
+        let noseTip = toPixel([nose.normalizedPoints.last ?? nose.normalizedPoints[nose.pointCount / 2]])
+
+        // Mouth corners: first and last points of outer lips
+        let outerPts = outerLips.normalizedPoints.map { $0 }
+        let leftMouth: CGPoint
+        let rightMouth: CGPoint
+        if outerPts.count >= 2 {
+            leftMouth = toPixel([outerPts[0]])
+            let midIdx = outerPts.count / 2
+            rightMouth = toPixel([outerPts[midIdx]])
+        } else {
+            return nil
+        }
+
+        return [
+            (leftEyeCenter.x, leftEyeCenter.y),
+            (rightEyeCenter.x, rightEyeCenter.y),
+            (noseTip.x, noseTip.y),
+            (leftMouth.x, leftMouth.y),
+            (rightMouth.x, rightMouth.y),
+        ]
+    }
+
+    // Estimate affine transform: dst = M * src
+    // Uses least-squares on first 3 point pairs (sufficient for affine)
+    private func estimateAffineTransform(src: [(CGFloat, CGFloat)],
+                                          dst: [(CGFloat, CGFloat)]) -> [CGFloat]? {
+        guard src.count >= 3, dst.count >= 3 else { return nil }
+
+        // Solve for 2x3 affine matrix using first 3 points
+        // [dst_x] = [a b c] [src_x]
+        // [dst_y]   [d e f] [src_y]
+        //                   [  1  ]
+        let s = src
+        let d = dst
+
+        // Build 6x6 system using all points for better accuracy
+        var A = [[Double]](repeating: [Double](repeating: 0, count: 6), count: min(src.count, 5) * 2)
+        var b = [Double](repeating: 0, count: min(src.count, 5) * 2)
+        let n = min(src.count, 5)
+
+        for i in 0..<n {
+            let row0 = i * 2
+            let row1 = i * 2 + 1
+            A[row0] = [Double(s[i].0), Double(s[i].1), 1, 0, 0, 0]
+            A[row1] = [0, 0, 0, Double(s[i].0), Double(s[i].1), 1]
+            b[row0] = Double(d[i].0)
+            b[row1] = Double(d[i].1)
+        }
+
+        // Solve using normal equations: x = (A^T A)^-1 A^T b
+        guard let result = solveLinearSystem(A: A, b: b) else { return nil }
+        return result.map { CGFloat($0) }
+    }
+
+    private func solveLinearSystem(A: [[Double]], b: [Double]) -> [Double]? {
+        let m = A.count
+        let n = 6
+
+        // Compute A^T * A (6x6)
+        var ATA = [[Double]](repeating: [Double](repeating: 0, count: n), count: n)
+        var ATb = [Double](repeating: 0, count: n)
+
+        for i in 0..<n {
+            for j in 0..<n {
+                for k in 0..<m {
+                    ATA[i][j] += A[k][i] * A[k][j]
+                }
+            }
+            for k in 0..<m {
+                ATb[i] += A[k][i] * b[k]
+            }
+        }
+
+        // Gaussian elimination with partial pivoting
+        var aug = ATA
+        var rhs = ATb
+        for col in 0..<n {
+            // Pivot
+            var maxVal = abs(aug[col][col])
+            var maxRow = col
+            for row in (col + 1)..<n {
+                if abs(aug[row][col]) > maxVal {
+                    maxVal = abs(aug[row][col])
+                    maxRow = row
+                }
+            }
+            if maxVal < 1e-12 { return nil }
+            if maxRow != col {
+                aug.swapAt(col, maxRow)
+                rhs.swapAt(col, maxRow)
+            }
+            // Eliminate
+            for row in (col + 1)..<n {
+                let factor = aug[row][col] / aug[col][col]
+                for j in col..<n { aug[row][j] -= factor * aug[col][j] }
+                rhs[row] -= factor * rhs[col]
+            }
+        }
+        // Back substitution
+        var x = [Double](repeating: 0, count: n)
+        for i in stride(from: n - 1, through: 0, by: -1) {
+            var sum = rhs[i]
+            for j in (i + 1)..<n { sum -= aug[i][j] * x[j] }
+            x[i] = sum / aug[i][i]
+        }
+        return x
+    }
+
+    // MARK: - Model prediction
+
+    private func predict(pixelBuffer: CVPixelBuffer) -> [Float]? {
+        guard let model = mlModel else { return nil }
+        guard let input = try? MLDictionaryFeatureProvider(
+            dictionary: ["face_image": MLFeatureValue(pixelBuffer: pixelBuffer)]
+        ) else { return nil }
+        guard let output = try? model.prediction(from: input) else { return nil }
+        guard let multiArray = output.featureValue(for: "embedding")?.multiArrayValue else { return nil }
+
+        let count = multiArray.count
+        guard count == 512 else { return nil }
+        // Use safe accessor instead of raw pointer cast
+        return (0..<count).map { multiArray[$0].floatValue }
+    }
+
+    // MARK: - Matching
+
+    private func findBestMatch(for embedding: [Float]) -> (FaceEmbedding?, Float) {
+        var bestMatch: FaceEmbedding?
+        var bestSim: Float = -1
+        for face in registered {
+            let sim = cosineSimilarity(embedding, face.embedding)
+            if sim > bestSim {
+                bestSim = sim
+                bestMatch = face
+            }
+        }
+        return (bestSim > 0.3 ? bestMatch : nil, bestSim)
+    }
+
+    private func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
+        guard a.count == b.count else { return 0 }
+        var dot: Float = 0
+        var normA: Float = 0
+        var normB: Float = 0
+        for i in 0..<a.count {
+            dot += a[i] * b[i]
+            normA += a[i] * a[i]
+            normB += b[i] * b[i]
+        }
+        let denom = sqrt(normA) * sqrt(normB)
+        return denom > 0 ? dot / denom : 0
+    }
+}
+
+extension UIImage {
+    func normalizedOrientation() -> UIImage {
+        guard imageOrientation != .up else { return self }
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        draw(in: CGRect(origin: .zero, size: size))
+        let normalized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return normalized ?? self
+    }
+}

--- a/creative_apps/AdaFaceDemo/AdaFaceDemo/Info.plist
+++ b/creative_apps/AdaFaceDemo/AdaFaceDemo/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSCameraUsageDescription</key>
+	<string>This app needs camera access for face recognition.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add AdaFace IR-18 face recognition demo app with Register / Compare / Live tabs
- Model (48MB) uploaded as release asset: [adaface-v1](https://github.com/john-rocky/CoreML-Models/releases/tag/adaface-v1)
- Includes conversion script (`convert_adaface.py`)

## Model
- **Input**: 112x112 face image (BGR)
- **Output**: 512-dim L2-normalized embedding
- **Architecture**: iResNet-18 (AdaFace, CVPR 2022)
- **License**: MIT

## Features
- **Register tab**: Register faces via photo library or camera, with name and thumbnail
- **Compare tab**: Radial similarity visualization — reference face at center, comparison images positioned by similarity score, 60% threshold for "Same Person" zone
- **Live tab**: Real-time camera recognition with face bounding box, name, similarity bar
- 5-point landmark alignment (VNDetectFaceLandmarksRequest) for consistent embeddings
- Cosine similarity matching with registered face database (UserDefaults)
- Camera image orientation normalization

## Test plan
- [ ] Download model from release, place in `AdaFaceDemo/AdaFaceDemo/`
- [ ] Register a face via photo and via camera
- [ ] Verify Live tab recognizes registered face with >60% similarity
- [ ] Verify Compare tab radial layout with multiple images