### PR TITLE
Add OpenVoice V2 voice conversion demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,6 +910,8 @@ AdaFace — Quality-adaptive face recognition. Outputs 512-dim embedding for fac
 
 OpenVoice — Zero-shot voice conversion. Record source and target voice, convert on-device.
 
+<video src="https://github.com/user-attachments/assets/70078691-14df-4350-846c-9ba1682433ce" width="300"></video>
+
 | Download Link | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
 | [OpenVoice_SpeakerEncoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/openvoice-v1/OpenVoice_SpeakerEncoder.mlpackage.zip) | 1.7 MB | Spectrogram [1, T, 513] | 256-dim speaker embedding | [myshell-ai/OpenVoice](https://github.com/myshell-ai/OpenVoice) | [MIT](https://github.com/myshell-ai/OpenVoice/blob/main/LICENSE) | 2024 | [OpenVoiceDemo](sample_apps/OpenVoiceDemo) | [convert_openvoice.py](conversion_scripts/convert_openvoice.py) |

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ You are free to do or not.
 - [**3D Face Pose Estimation**](#3d-face-pose-estimation)
   - [3DDFA_V2](#3ddfa_v2)
 
+- [**Voice Conversion**](#voice-conversion)
+  - [OpenVoice V2](#openvoice-v2)
+
 - [**Audio Source Separation**](#audio-source-separation)
   - [HTDemucs](#htdemucs)
 
@@ -900,6 +903,17 @@ AdaFace — Quality-adaptive face recognition. Outputs 512-dim embedding for fac
 | Download Link | Size | Input | Output | Original Project | License | Year | Sample Project |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
 | [3DDFA_V2.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/face3d-v1/3DDFA_V2.mlpackage.zip) | 6.3 MB | Image (120×120 RGB) | 62 params (12 pose + 40 shape + 10 expression) | [cleardusk/3DDFA_V2](https://github.com/cleardusk/3DDFA_V2) | [MIT](https://github.com/cleardusk/3DDFA_V2/blob/master/LICENSE) | 2020 | [Face3DDemo](sample_apps/Face3DDemo) |
+
+# Voice Conversion
+
+### OpenVoice V2
+
+OpenVoice — Zero-shot voice conversion. Record source and target voice, convert on-device.
+
+| Download Link | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| [OpenVoice_SpeakerEncoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/openvoice-v1/OpenVoice_SpeakerEncoder.mlpackage.zip) | 1.7 MB | Spectrogram [1, T, 513] | 256-dim speaker embedding | [myshell-ai/OpenVoice](https://github.com/myshell-ai/OpenVoice) | [MIT](https://github.com/myshell-ai/OpenVoice/blob/main/LICENSE) | 2024 | [OpenVoiceDemo](sample_apps/OpenVoiceDemo) | [convert_openvoice.py](conversion_scripts/convert_openvoice.py) |
+| [OpenVoice_VoiceConverter.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/openvoice-v1/OpenVoice_VoiceConverter.mlpackage.zip) | 64 MB | Spectrogram + speaker embeddings | Waveform audio (22050 Hz) | | | | | |
 
 # Audio Source Separation
 

--- a/conversion_scripts/convert_openvoice.py
+++ b/conversion_scripts/convert_openvoice.py
@@ -1,0 +1,221 @@
+"""
+Convert OpenVoice V2 voice conversion models to CoreML.
+
+Usage:
+    python3 convert_openvoice.py
+
+Output:
+    sample_apps/OpenVoiceDemo/OpenVoiceDemo/OpenVoice_SpeakerEncoder.mlpackage
+    sample_apps/OpenVoiceDemo/OpenVoiceDemo/OpenVoice_VoiceConverter.mlpackage
+
+Model: OpenVoice V2 (MyShell AI)
+  - SpeakerEncoder: mel spectrogram → 256-dim speaker embedding
+  - VoiceConverter: spectrogram + src/tgt speaker embeddings → waveform
+  - License: MIT
+  - Repo: https://github.com/myshell-ai/OpenVoice
+"""
+
+import sys
+sys.path.insert(0, '/tmp/openvoice_repo')
+
+import torch
+import torch.nn as nn
+import json
+import os
+import coremltools as ct
+from openvoice.models import SynthesizerTrn
+from openvoice import utils
+
+HF_DIR = os.path.expanduser(
+    "~/.cache/huggingface/hub/models--myshell-ai--OpenVoiceV2/snapshots/"
+)
+# Find snapshot dir
+snapshot = next(os.listdir(HF_DIR).__iter__())
+HF_DIR = os.path.join(HF_DIR, snapshot)
+
+CONVERTER_DIR = os.path.join(HF_DIR, "converter")
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "..", "sample_apps", "OpenVoiceDemo", "OpenVoiceDemo")
+
+
+def load_model():
+    """Load the OpenVoice V2 converter model."""
+    with open(os.path.join(CONVERTER_DIR, "config.json")) as f:
+        config = json.load(f)
+
+    hps = utils.HParams(**config)
+    m = hps.model
+    model = SynthesizerTrn(
+        n_vocab=0,
+        spec_channels=hps.data.filter_length // 2 + 1,  # 513
+        inter_channels=m.inter_channels,
+        hidden_channels=m.hidden_channels,
+        filter_channels=m.filter_channels,
+        n_heads=m.n_heads,
+        n_layers=m.n_layers,
+        kernel_size=m.kernel_size,
+        p_dropout=m.p_dropout,
+        resblock=m.resblock,
+        resblock_kernel_sizes=m.resblock_kernel_sizes,
+        resblock_dilation_sizes=m.resblock_dilation_sizes,
+        upsample_rates=m.upsample_rates,
+        upsample_initial_channel=m.upsample_initial_channel,
+        upsample_kernel_sizes=m.upsample_kernel_sizes,
+        n_speakers=0,
+        gin_channels=m.gin_channels,
+        zero_g=m.zero_g,
+    )
+
+    ckpt = torch.load(os.path.join(CONVERTER_DIR, "checkpoint.pth"),
+                       map_location="cpu", weights_only=False)
+    state = ckpt.get("model", ckpt)
+    model.load_state_dict(state, strict=False)
+    model.eval()
+
+    # Remove weight_norm for export
+    model.dec.remove_weight_norm()
+    for layer in model.flow.flows:
+        if hasattr(layer, 'remove_weight_norm'):
+            layer.remove_weight_norm()
+    for layer in model.enc_q.enc.in_layers:
+        torch.nn.utils.remove_weight_norm(layer)
+
+    return model, hps
+
+
+class SpeakerEncoderWrapper(nn.Module):
+    """Wraps ref_enc to extract speaker embedding from mel spectrogram."""
+    def __init__(self, ref_enc):
+        super().__init__()
+        self.ref_enc = ref_enc
+
+    def forward(self, spec_t):
+        # spec_t: [1, T, 513] (transposed spectrogram)
+        se = self.ref_enc(spec_t)  # [1, 256]
+        return se.unsqueeze(-1)  # [1, 256, 1]
+
+
+class VoiceConverterWrapper(nn.Module):
+    """Wraps enc_q + flow + dec for voice conversion."""
+    def __init__(self, enc_q, flow, dec, zero_g=True):
+        super().__init__()
+        self.enc_q = enc_q
+        self.flow = flow
+        self.dec = dec
+        self.zero_g = zero_g
+
+    def forward(self, spec, spec_lengths, src_se, tgt_se):
+        # spec: [1, 513, T]
+        # spec_lengths: [1] (int, actual T value)
+        # src_se, tgt_se: [1, 256, 1]
+
+        g_src = src_se
+        if self.zero_g:
+            g_src_enc = torch.zeros_like(src_se)
+        else:
+            g_src_enc = src_se
+
+        # Encode
+        z, m_q, logs_q, mask = self.enc_q(spec, spec_lengths, g=g_src_enc, tau=0.3)
+
+        # Flow: source → target
+        z_p = self.flow(z, mask, g=src_se)
+        z_hat = self.flow(z_p, mask, g=tgt_se, reverse=True)
+
+        # Decode
+        if self.zero_g:
+            g_dec = torch.zeros_like(tgt_se)
+        else:
+            g_dec = tgt_se
+
+        audio = self.dec(z_hat * mask, g=g_dec)
+        return audio
+
+
+def convert_speaker_encoder(model):
+    print("\n=== Converting SpeakerEncoder ===")
+    wrapper = SpeakerEncoderWrapper(model.ref_enc)
+    wrapper.eval()
+
+    # Input: [1, T, 513] - T is variable
+    dummy = torch.randn(1, 100, 513)
+    with torch.no_grad():
+        out = wrapper(dummy)
+    print(f"Output shape: {out.shape}")
+
+    traced = torch.jit.trace(wrapper, dummy)
+
+    mlmodel = ct.convert(
+        traced,
+        inputs=[ct.TensorType(name="spectrogram", shape=ct.Shape(
+            shape=(1, ct.RangeDim(lower_bound=10, upper_bound=1000, default=100), 513)
+        ))],
+        outputs=[ct.TensorType(name="speaker_embedding")],
+        minimum_deployment_target=ct.target.iOS16,
+    )
+
+    mlmodel.author = "CoreML-Models"
+    mlmodel.short_description = "OpenVoice V2 Speaker Encoder: extracts 256-dim speaker embedding from spectrogram."
+    mlmodel.license = "MIT"
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    path = os.path.join(OUTPUT_DIR, "OpenVoice_SpeakerEncoder.mlpackage")
+    mlmodel.save(path)
+    size = sum(os.path.getsize(os.path.join(dp, f))
+               for dp, _, fns in os.walk(path) for f in fns) / 1e6
+    print(f"Saved to {path} ({size:.1f} MB)")
+
+
+def convert_voice_converter(model, hps):
+    print("\n=== Converting VoiceConverter ===")
+    zero_g = getattr(hps.model, 'zero_g', True)
+    wrapper = VoiceConverterWrapper(model.enc_q, model.flow, model.dec, zero_g=zero_g)
+    wrapper.eval()
+
+    T = 100
+    dummy_spec = torch.randn(1, 513, T)
+    dummy_lengths = torch.tensor([T], dtype=torch.long)
+    dummy_src_se = torch.randn(1, 256, 1)
+    dummy_tgt_se = torch.randn(1, 256, 1)
+
+    with torch.no_grad():
+        out = wrapper(dummy_spec, dummy_lengths, dummy_src_se, dummy_tgt_se)
+    print(f"Output shape: {out.shape}")
+
+    print("Tracing model...")
+    traced = torch.jit.trace(wrapper, (dummy_spec, dummy_lengths, dummy_src_se, dummy_tgt_se))
+
+    print("Converting to CoreML...")
+    mlmodel = ct.convert(
+        traced,
+        inputs=[
+            ct.TensorType(name="spectrogram", shape=ct.Shape(
+                shape=(1, 513, ct.RangeDim(lower_bound=10, upper_bound=1000, default=100))
+            )),
+            ct.TensorType(name="spec_lengths", shape=(1,)),
+            ct.TensorType(name="source_speaker", shape=(1, 256, 1)),
+            ct.TensorType(name="target_speaker", shape=(1, 256, 1)),
+        ],
+        outputs=[ct.TensorType(name="audio")],
+        minimum_deployment_target=ct.target.iOS16,
+    )
+
+    mlmodel.author = "CoreML-Models"
+    mlmodel.short_description = "OpenVoice V2 Voice Converter: converts voice from source to target speaker."
+    mlmodel.license = "MIT"
+
+    path = os.path.join(OUTPUT_DIR, "OpenVoice_VoiceConverter.mlpackage")
+    mlmodel.save(path)
+    size = sum(os.path.getsize(os.path.join(dp, f))
+               for dp, _, fns in os.walk(path) for f in fns) / 1e6
+    print(f"Saved to {path} ({size:.1f} MB)")
+
+
+def main():
+    model, hps = load_model()
+    convert_speaker_encoder(model)
+    convert_voice_converter(model, hps)
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample_apps/OpenVoiceDemo/OpenVoiceDemo.xcodeproj/project.pbxproj
+++ b/sample_apps/OpenVoiceDemo/OpenVoiceDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,351 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B10000010000000000000001 /* OpenVoiceDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000001 /* OpenVoiceDemoApp.swift */; };
+		B10000010000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000002 /* ContentView.swift */; };
+		B10000010000000000000003 /* VoiceConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000003 /* VoiceConverter.swift */; };
+		B10000010000000000000004 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000004 /* Assets.xcassets */; };
+		B10000010000000000000006 /* OpenVoice_SpeakerEncoder.mlpackage in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000006 /* OpenVoice_SpeakerEncoder.mlpackage */; };
+		B10000010000000000000007 /* OpenVoice_VoiceConverter.mlpackage in Sources */ = {isa = PBXBuildFile; fileRef = B10000020000000000000007 /* OpenVoice_VoiceConverter.mlpackage */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B10000020000000000000001 /* OpenVoiceDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenVoiceDemoApp.swift; sourceTree = "<group>"; };
+		B10000020000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B10000020000000000000003 /* VoiceConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceConverter.swift; sourceTree = "<group>"; };
+		B10000020000000000000004 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B10000020000000000000005 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B10000020000000000000006 /* OpenVoice_SpeakerEncoder.mlpackage */ = {isa = PBXFileReference; lastKnownFileType = folder.mlpackage; path = OpenVoice_SpeakerEncoder.mlpackage; sourceTree = "<group>"; };
+		B10000020000000000000007 /* OpenVoice_VoiceConverter.mlpackage */ = {isa = PBXFileReference; lastKnownFileType = folder.mlpackage; path = OpenVoice_VoiceConverter.mlpackage; sourceTree = "<group>"; };
+		B10000020000000000000010 /* OpenVoiceDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenVoiceDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B10000030000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B10000040000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				B10000040000000000000002 /* OpenVoiceDemo */,
+				B10000040000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B10000040000000000000002 /* OpenVoiceDemo */ = {
+			isa = PBXGroup;
+			children = (
+				B10000020000000000000001 /* OpenVoiceDemoApp.swift */,
+				B10000020000000000000002 /* ContentView.swift */,
+				B10000020000000000000003 /* VoiceConverter.swift */,
+				B10000020000000000000006 /* OpenVoice_SpeakerEncoder.mlpackage */,
+				B10000020000000000000007 /* OpenVoice_VoiceConverter.mlpackage */,
+				B10000020000000000000004 /* Assets.xcassets */,
+				B10000020000000000000005 /* Info.plist */,
+			);
+			path = OpenVoiceDemo;
+			sourceTree = "<group>";
+		};
+		B10000040000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B10000020000000000000010 /* OpenVoiceDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B10000050000000000000001 /* OpenVoiceDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B10000070000000000000001;
+			buildPhases = (
+				B10000060000000000000001 /* Sources */,
+				B10000030000000000000001 /* Frameworks */,
+				B10000060000000000000002 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OpenVoiceDemo;
+			productName = OpenVoiceDemo;
+			productReference = B10000020000000000000010 /* OpenVoiceDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B10000080000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					B10000050000000000000001 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = B10000070000000000000003;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B10000040000000000000001;
+			productRefGroup = B10000040000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B10000050000000000000001 /* OpenVoiceDemo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B10000060000000000000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B10000010000000000000004 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B10000060000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B10000010000000000000006 /* OpenVoice_SpeakerEncoder.mlpackage in Sources */,
+				B10000010000000000000007 /* OpenVoice_VoiceConverter.mlpackage in Sources */,
+				B10000010000000000000001 /* OpenVoiceDemoApp.swift in Sources */,
+				B10000010000000000000002 /* ContentView.swift in Sources */,
+				B10000010000000000000003 /* VoiceConverter.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		B10000090000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B10000090000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B10000090000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MFN25KNUGJ;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OpenVoiceDemo/Info.plist;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app needs microphone access for voice recording.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.coreml-models.openvoicedemo";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B10000090000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MFN25KNUGJ;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OpenVoiceDemo/Info.plist;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app needs microphone access for voice recording.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.coreml-models.openvoicedemo";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B10000070000000000000001 /* Build configuration list for PBXNativeTarget "OpenVoiceDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B10000090000000000000003 /* Debug */,
+				B10000090000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B10000070000000000000003 /* Build configuration list for PBXProject "OpenVoiceDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B10000090000000000000001 /* Debug */,
+				B10000090000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = B10000080000000000000001 /* Project object */;
+}

--- a/sample_apps/OpenVoiceDemo/OpenVoiceDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/sample_apps/OpenVoiceDemo/OpenVoiceDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/OpenVoiceDemo/OpenVoiceDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/sample_apps/OpenVoiceDemo/OpenVoiceDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/OpenVoiceDemo/OpenVoiceDemo/Assets.xcassets/Contents.json
+++ b/sample_apps/OpenVoiceDemo/OpenVoiceDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/OpenVoiceDemo/OpenVoiceDemo/ContentView.swift
+++ b/sample_apps/OpenVoiceDemo/OpenVoiceDemo/ContentView.swift
@@ -1,0 +1,357 @@
+import SwiftUI
+import AVFoundation
+import UniformTypeIdentifiers
+
+struct ContentView: View {
+    @StateObject private var converter = VoiceConverter()
+    @StateObject private var sourceRecorder = AudioRecorder()
+    @StateObject private var targetRecorder = AudioRecorder()
+    @State private var status = ""
+    @State private var convertedURL: URL?
+    @State private var isConverting = false
+    @State private var player: AVAudioPlayer?
+    @State private var showTargetImport = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 28) {
+                    // Model status
+                    HStack {
+                        Circle().fill(converter.isReady ? .green : .red).frame(width: 10, height: 10)
+                        Text(converter.isReady ? "Models loaded" : converter.status)
+                            .font(.caption).foregroundColor(.secondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal)
+
+                    // Source voice
+                    RecordSection(
+                        title: "Your Voice",
+                        subtitle: "Record what you want to say",
+                        icon: "person.wave.2",
+                        color: .blue,
+                        recorder: sourceRecorder,
+                        enabled: converter.isReady,
+                        onPlay: { if let u = sourceRecorder.recordedURL { playAudio(url: u) } }
+                    )
+
+                    // Target voice
+                    VStack(spacing: 12) {
+                        HStack {
+                            Image(systemName: "person.2.wave.2")
+                                .foregroundColor(.purple)
+                            Text("Target Voice").font(.headline)
+                            Spacer()
+                        }
+                        .padding(.horizontal)
+
+                        Text("Record or import a sample of the voice you want to sound like")
+                            .font(.caption).foregroundColor(.secondary)
+                            .padding(.horizontal)
+
+                        HStack(spacing: 16) {
+                            // Record target
+                            Button {
+                                if targetRecorder.isRecording {
+                                    targetRecorder.stop()
+                                } else {
+                                    targetRecorder.start()
+                                }
+                            } label: {
+                                VStack(spacing: 6) {
+                                    ZStack {
+                                        Circle()
+                                            .fill(targetRecorder.isRecording ? .red : .purple)
+                                            .frame(width: 60, height: 60)
+                                        Image(systemName: targetRecorder.isRecording ? "stop.fill" : "mic.fill")
+                                            .font(.title3).foregroundColor(.white)
+                                    }
+                                    Text(targetRecorder.isRecording ? "Stop" : "Record")
+                                        .font(.caption2)
+                                }
+                            }
+                            .disabled(!converter.isReady)
+
+                            // Import target
+                            Button {
+                                showTargetImport = true
+                            } label: {
+                                VStack(spacing: 6) {
+                                    ZStack {
+                                        Circle().fill(.purple.opacity(0.2)).frame(width: 60, height: 60)
+                                        Image(systemName: "doc.badge.plus")
+                                            .font(.title3).foregroundColor(.purple)
+                                    }
+                                    Text("Import").font(.caption2)
+                                }
+                            }
+
+                            // Play target
+                            if targetRecorder.recordedURL != nil {
+                                Button {
+                                    playAudio(url: targetRecorder.recordedURL!)
+                                } label: {
+                                    VStack(spacing: 6) {
+                                        ZStack {
+                                            Circle().fill(.purple.opacity(0.2)).frame(width: 60, height: 60)
+                                            Image(systemName: "play.fill")
+                                                .font(.title3).foregroundColor(.purple)
+                                        }
+                                        Text("Play").font(.caption2)
+                                    }
+                                }
+                            }
+                        }
+
+                        if let dur = targetRecorder.duration {
+                            Text(String(format: "Target: %.1f sec", dur))
+                                .font(.caption2).foregroundColor(.secondary)
+                        }
+                    }
+                    .padding()
+                    .background(RoundedRectangle(cornerRadius: 16).fill(.purple.opacity(0.05)))
+                    .padding(.horizontal)
+
+                    // Convert button
+                    Button {
+                        convert()
+                    } label: {
+                        HStack {
+                            if isConverting {
+                                ProgressView().controlSize(.small).tint(.white)
+                            }
+                            Image(systemName: "waveform.path.ecg")
+                            Text(isConverting ? "Converting..." : "Convert Voice")
+                                .bold()
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange)
+                    .disabled(sourceRecorder.recordedURL == nil ||
+                              targetRecorder.recordedURL == nil ||
+                              isConverting || !converter.isReady)
+                    .padding(.horizontal)
+
+                    // Status
+                    if !status.isEmpty {
+                        Text(status)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                    }
+
+                    // Play converted
+                    if let url = convertedURL {
+                        Button {
+                            playAudio(url: url)
+                        } label: {
+                            Label("Play Converted Voice", systemImage: "play.circle.fill")
+                                .font(.title3).bold()
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.green)
+                        .padding(.horizontal)
+
+                        // Share
+                        ShareLink(item: url) {
+                            Label("Share", systemImage: "square.and.arrow.up")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .padding(.horizontal)
+                    }
+                }
+                .padding(.vertical)
+            }
+            .navigationTitle("Voice Conversion")
+            .fileImporter(isPresented: $showTargetImport,
+                          allowedContentTypes: [.audio, .wav, .mp3, .mpeg4Audio]) { result in
+                if case .success(let url) = result {
+                    targetRecorder.setImported(url: url)
+                }
+            }
+        }
+    }
+
+    private func convert() {
+        guard let sourceURL = sourceRecorder.recordedURL,
+              let targetURL = targetRecorder.recordedURL else { return }
+        isConverting = true
+        convertedURL = nil
+
+        Task {
+            do {
+                await MainActor.run { status = "Extracting your voice profile..." }
+                let srcSE = try await converter.extractSpeakerEmbedding(audioURL: sourceURL)
+
+                await MainActor.run { status = "Extracting target voice profile..." }
+                let tgtSE = try await converter.extractSpeakerEmbedding(audioURL: targetURL)
+
+                let result = try await converter.convert(
+                    sourceURL: sourceURL,
+                    sourceSE: srcSE,
+                    targetSE: tgtSE
+                ) { msg in
+                    DispatchQueue.main.async { status = msg }
+                }
+
+                await MainActor.run {
+                    convertedURL = result
+                    status = "Done!"
+                    isConverting = false
+                }
+            } catch {
+                await MainActor.run {
+                    status = "Error: \(error.localizedDescription)"
+                    isConverting = false
+                }
+            }
+        }
+    }
+
+    private func playAudio(url: URL) {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback)
+            try AVAudioSession.sharedInstance().setActive(true)
+            player = try AVAudioPlayer(contentsOf: url)
+            player?.play()
+        } catch {
+            status = "Playback error: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Record Section
+
+struct RecordSection: View {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let color: Color
+    let recorder: AudioRecorder
+    let enabled: Bool
+    let onPlay: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Image(systemName: icon).foregroundColor(color)
+                Text(title).font(.headline)
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            Text(subtitle)
+                .font(.caption).foregroundColor(.secondary)
+                .padding(.horizontal)
+
+            HStack(spacing: 16) {
+                Button {
+                    if recorder.isRecording {
+                        recorder.stop()
+                    } else {
+                        recorder.start()
+                    }
+                } label: {
+                    VStack(spacing: 6) {
+                        ZStack {
+                            Circle()
+                                .fill(recorder.isRecording ? .red : color)
+                                .frame(width: 60, height: 60)
+                            Image(systemName: recorder.isRecording ? "stop.fill" : "mic.fill")
+                                .font(.title3).foregroundColor(.white)
+                        }
+                        Text(recorder.isRecording ? "Stop" : "Record").font(.caption2)
+                    }
+                }
+                .disabled(!enabled)
+
+                if recorder.recordedURL != nil {
+                    Button(action: onPlay) {
+                        VStack(spacing: 6) {
+                            ZStack {
+                                Circle().fill(color.opacity(0.2)).frame(width: 60, height: 60)
+                                Image(systemName: "play.fill")
+                                    .font(.title3).foregroundColor(color)
+                            }
+                            Text("Play").font(.caption2)
+                        }
+                    }
+                }
+            }
+
+            if let dur = recorder.duration {
+                Text(String(format: "%.1f sec", dur))
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16).fill(color.opacity(0.05)))
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Audio Recorder
+
+class AudioRecorder: ObservableObject {
+    @Published var isRecording = false
+    @Published var recordedURL: URL?
+    @Published var duration: Double?
+
+    private var audioRecorder: AVAudioRecorder?
+
+    func start() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.record, mode: .default)
+            try session.setActive(true)
+        } catch { return }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rec_\(UUID().uuidString).wav")
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatLinearPCM),
+            AVSampleRateKey: 22050.0,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+        ]
+
+        guard let rec = try? AVAudioRecorder(url: url, settings: settings) else { return }
+        audioRecorder = rec
+        rec.record()
+        isRecording = true
+        recordedURL = nil
+        duration = nil
+    }
+
+    func stop() {
+        guard let rec = audioRecorder else { return }
+        rec.stop()
+        isRecording = false
+        recordedURL = rec.url
+        if let file = try? AVAudioFile(forReading: rec.url) {
+            duration = Double(file.length) / file.fileFormat.sampleRate
+        }
+    }
+
+    func setImported(url: URL) {
+        // Copy to temp so we have read access
+        let dest = FileManager.default.temporaryDirectory
+            .appendingPathComponent("import_\(UUID().uuidString).\(url.pathExtension)")
+        guard url.startAccessingSecurityScopedResource() else { return }
+        defer { url.stopAccessingSecurityScopedResource() }
+        try? FileManager.default.copyItem(at: url, to: dest)
+        recordedURL = dest
+        if let file = try? AVAudioFile(forReading: dest) {
+            duration = Double(file.length) / file.fileFormat.sampleRate
+        }
+    }
+}

--- a/sample_apps/OpenVoiceDemo/OpenVoiceDemo/Info.plist
+++ b/sample_apps/OpenVoiceDemo/OpenVoiceDemo/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app needs microphone access for voice recording.</string>
+</dict>
+</plist>

--- a/sample_apps/OpenVoiceDemo/OpenVoiceDemo/OpenVoiceDemoApp.swift
+++ b/sample_apps/OpenVoiceDemo/OpenVoiceDemo/OpenVoiceDemoApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct OpenVoiceDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/sample_apps/OpenVoiceDemo/OpenVoiceDemo/VoiceConverter.swift
+++ b/sample_apps/OpenVoiceDemo/OpenVoiceDemo/VoiceConverter.swift
@@ -1,0 +1,285 @@
+import CoreML
+import AVFoundation
+import Accelerate
+
+class VoiceConverter: ObservableObject {
+    private var encoderModel: MLModel?
+    private var converterModel: MLModel?
+    @Published var isReady = false
+    @Published var status = "Loading models..."
+
+    // OpenVoice V2 audio parameters
+    static let sampleRate: Double = 22050
+    static let nFFT = 1024
+    static let hopLength = 256
+    static let winLength = 1024
+
+    init() {
+        loadModels()
+    }
+
+    private func loadModels() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self, let resourcePath = Bundle.main.resourcePath else { return }
+            let fm = FileManager.default
+            guard let items = try? fm.contentsOfDirectory(atPath: resourcePath) else { return }
+
+            let config = MLModelConfiguration()
+            config.computeUnits = .all
+
+            for item in items where item.hasSuffix(".mlmodelc") {
+                let url = URL(fileURLWithPath: (resourcePath as NSString).appendingPathComponent(item))
+                guard let model = try? MLModel(contentsOf: url, configuration: config) else { continue }
+                if item.contains("SpeakerEncoder") {
+                    self.encoderModel = model
+                } else if item.contains("VoiceConverter") {
+                    self.converterModel = model
+                }
+            }
+
+            let ready = self.encoderModel != nil && self.converterModel != nil
+            DispatchQueue.main.async {
+                self.isReady = ready
+                self.status = ready ? "Ready" : "Failed to load models"
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    func extractSpeakerEmbedding(audioURL: URL) async throws -> [Float] {
+        let samples = try loadAudio(url: audioURL)
+        let spec = stft(samples: samples)
+        // spec is [freqBins, frames] = [513, T]
+        // SpeakerEncoder expects [1, T, 513] (transposed)
+        let T = spec.count / 513
+        let transposed = transposeSpec(spec, freqBins: 513, frames: T)
+
+        guard let encoder = encoderModel else { throw VoiceError.modelNotLoaded }
+        let inputArray = try MLMultiArray(shape: [1, T as NSNumber, 513], dataType: .float32)
+        for i in 0..<transposed.count {
+            inputArray[i] = NSNumber(value: transposed[i])
+        }
+
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "spectrogram": MLFeatureValue(multiArray: inputArray)
+        ])
+        let output = try encoder.prediction(from: input)
+        guard let se = output.featureValue(for: "speaker_embedding")?.multiArrayValue else {
+            throw VoiceError.predictionFailed
+        }
+
+        return (0..<se.count).map { se[$0].floatValue }
+    }
+
+    func convert(sourceURL: URL, sourceSE: [Float], targetSE: [Float],
+                 progress: @escaping (String) -> Void) async throws -> URL {
+        progress("Loading audio...")
+        let samples = try loadAudio(url: sourceURL)
+
+        progress("Computing spectrogram...")
+        let spec = stft(samples: samples)
+        let T = spec.count / 513
+
+        progress("Converting voice...")
+        guard let converter = converterModel else { throw VoiceError.modelNotLoaded }
+
+        let specArray = try MLMultiArray(shape: [1, 513, T as NSNumber], dataType: .float32)
+        for i in 0..<spec.count { specArray[i] = NSNumber(value: spec[i]) }
+
+        let specLengths = try MLMultiArray(shape: [1], dataType: .float32)
+        specLengths[0] = NSNumber(value: T)
+
+        let srcSEArray = try MLMultiArray(shape: [1, 256, 1], dataType: .float32)
+        for i in 0..<256 { srcSEArray[i] = NSNumber(value: sourceSE[i]) }
+
+        let tgtSEArray = try MLMultiArray(shape: [1, 256, 1], dataType: .float32)
+        for i in 0..<256 { tgtSEArray[i] = NSNumber(value: targetSE[i]) }
+
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "spectrogram": MLFeatureValue(multiArray: specArray),
+            "spec_lengths": MLFeatureValue(multiArray: specLengths),
+            "source_speaker": MLFeatureValue(multiArray: srcSEArray),
+            "target_speaker": MLFeatureValue(multiArray: tgtSEArray),
+        ])
+
+        let output = try converter.prediction(from: input)
+        guard let audioOut = output.featureValue(for: "audio")?.multiArrayValue else {
+            throw VoiceError.predictionFailed
+        }
+
+        progress("Saving audio...")
+        let audioSamples = (0..<audioOut.count).map { audioOut[$0].floatValue }
+        let outputURL = try saveWAV(samples: audioSamples, sampleRate: Self.sampleRate)
+
+        progress("Done!")
+        return outputURL
+    }
+
+    // MARK: - Audio I/O
+
+    private func loadAudio(url: URL) throws -> [Float] {
+        let file = try AVAudioFile(forReading: url)
+        let originalFormat = file.processingFormat
+        let frameCount = AVAudioFrameCount(file.length)
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: originalFormat, frameCapacity: frameCount) else {
+            throw VoiceError.audioLoadFailed
+        }
+        try file.read(into: buffer)
+
+        // Resample to 22050 Hz mono
+        let targetFormat = AVAudioFormat(standardFormatWithSampleRate: Self.sampleRate, channels: 1)!
+        guard let converter = AVAudioConverter(from: originalFormat, to: targetFormat) else {
+            throw VoiceError.audioLoadFailed
+        }
+
+        let ratio = Self.sampleRate / originalFormat.sampleRate
+        let outputFrameCount = AVAudioFrameCount(Double(frameCount) * ratio)
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outputFrameCount) else {
+            throw VoiceError.audioLoadFailed
+        }
+
+        var isDone = false
+        let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+            if isDone {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            isDone = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+
+        try converter.convert(to: outputBuffer, error: nil, withInputFrom: inputBlock)
+
+        guard let channelData = outputBuffer.floatChannelData else {
+            throw VoiceError.audioLoadFailed
+        }
+        let count = Int(outputBuffer.frameLength)
+        return Array(UnsafeBufferPointer(start: channelData[0], count: count))
+    }
+
+    private func saveWAV(samples: [Float], sampleRate: Double) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".wav")
+
+        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count)) else {
+            throw VoiceError.audioSaveFailed
+        }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+
+        let dst = buffer.floatChannelData![0]
+        // Normalize to prevent clipping
+        let maxVal = samples.map { abs($0) }.max() ?? 1.0
+        let scale = maxVal > 1.0 ? 0.95 / maxVal : 1.0
+        for i in 0..<samples.count {
+            dst[i] = samples[i] * scale
+        }
+
+        try file.write(from: buffer)
+        return url
+    }
+
+    // MARK: - STFT (matches OpenVoice: n_fft=1024, hop=256, win=1024, center=False, reflect pad)
+
+    private func stft(samples: [Float]) -> [Float] {
+        let padAmount = (Self.nFFT - Self.hopLength) / 2  // 384
+        var padded = [Float](repeating: 0, count: samples.count + padAmount * 2)
+        // Reflect padding
+        for i in 0..<padAmount {
+            padded[padAmount - 1 - i] = samples[min(i + 1, samples.count - 1)]
+        }
+        for i in 0..<samples.count {
+            padded[padAmount + i] = samples[i]
+        }
+        for i in 0..<padAmount {
+            padded[padAmount + samples.count + i] = samples[max(samples.count - 2 - i, 0)]
+        }
+
+        let freqBins = Self.nFFT / 2 + 1  // 513
+        let numFrames = (padded.count - Self.nFFT) / Self.hopLength + 1
+
+        // Periodic Hann window (matches torch.hann_window(periodic=True))
+        var window = [Float](repeating: 0, count: Self.nFFT)
+        for i in 0..<Self.nFFT {
+            window[i] = 0.5 * (1.0 - cos(2.0 * .pi * Float(i) / Float(Self.nFFT)))
+        }
+
+        let log2n = vDSP_Length(log2(Float(Self.nFFT)))
+        guard let fftSetup = vDSP_create_fftsetup(log2n, FFTRadix(kFFTRadix2)) else {
+            return []
+        }
+        defer { vDSP_destroy_fftsetup(fftSetup) }
+
+        var result = [Float](repeating: 0, count: freqBins * numFrames)
+        let halfN = Self.nFFT / 2
+
+        for frame in 0..<numFrames {
+            let start = frame * Self.hopLength
+            var windowed = [Float](repeating: 0, count: Self.nFFT)
+            vDSP_vmul(Array(padded[start..<start + Self.nFFT]), 1, window, 1, &windowed, 1, vDSP_Length(Self.nFFT))
+
+            var realp = [Float](repeating: 0, count: halfN)
+            var imagp = [Float](repeating: 0, count: halfN)
+
+            realp.withUnsafeMutableBufferPointer { rBuf in
+                imagp.withUnsafeMutableBufferPointer { iBuf in
+                    var split = DSPSplitComplex(realp: rBuf.baseAddress!, imagp: iBuf.baseAddress!)
+
+                    windowed.withUnsafeBufferPointer { wBuf in
+                        wBuf.baseAddress!.withMemoryRebound(to: DSPComplex.self, capacity: halfN) { complex in
+                            vDSP_ctoz(complex, 2, &split, 1, vDSP_Length(halfN))
+                        }
+                    }
+
+                    vDSP_fft_zrip(fftSetup, &split, 1, log2n, FFTDirection(FFT_FORWARD))
+
+                    // vDSP forward FFT scales non-DC/Nyquist bins by 2.
+                    // torch.stft(normalized=False) has no extra scaling.
+                    // DC (realp[0]) and Nyquist (imagp[0]) are NOT doubled by vDSP.
+                    let dc = rBuf[0]
+                    result[0 * numFrames + frame] = sqrt(dc * dc + 1e-6)
+
+                    let ny = iBuf[0]
+                    result[(freqBins - 1) * numFrames + frame] = sqrt(ny * ny + 1e-6)
+
+                    for k in 1..<(freqBins - 1) {
+                        let r = rBuf[k] / 2.0  // undo vDSP 2x scaling
+                        let im = iBuf[k] / 2.0
+                        result[k * numFrames + frame] = sqrt(r * r + im * im + 1e-6)
+                    }
+                }
+            }
+        }
+
+        return result
+    }
+
+    private func transposeSpec(_ spec: [Float], freqBins: Int, frames: Int) -> [Float] {
+        // [freqBins, frames] → [frames, freqBins]
+        var transposed = [Float](repeating: 0, count: spec.count)
+        for f in 0..<freqBins {
+            for t in 0..<frames {
+                transposed[t * freqBins + f] = spec[f * frames + t]
+            }
+        }
+        return transposed
+    }
+}
+
+enum VoiceError: LocalizedError {
+    case modelNotLoaded, predictionFailed, audioLoadFailed, audioSaveFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .modelNotLoaded: return "Model not loaded"
+        case .predictionFailed: return "Prediction failed"
+        case .audioLoadFailed: return "Failed to load audio"
+        case .audioSaveFailed: return "Failed to save audio"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add OpenVoice V2 zero-shot voice conversion demo app
- Models uploaded as release assets: [openvoice-v1](https://github.com/john-rocky/CoreML-Models/releases/tag/openvoice-v1)
- Includes conversion script (`convert_openvoice.py`)

## Models
- **SpeakerEncoder** (1.7 MB): Extracts 256-dim speaker embedding from spectrogram
- **VoiceConverter** (64 MB): Converts voice from source to target speaker embedding

## Features
- Record source voice (what you want to say)
- Record or import target voice (voice you want to sound like)
- On-device speaker embedding extraction + voice conversion
- Playback and share converted audio
- Swift STFT implementation using Accelerate vDSP

## Test plan
- [ ] Download both models from release, place in `OpenVoiceDemo/OpenVoiceDemo/`
- [ ] Record source voice (~3-5 sec)
- [ ] Record or import target voice
- [ ] Convert and verify output sounds like target voice with source content