### PR TITLE
Add DDColor Tiny image colorization demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,6 +889,10 @@ Pastel Mix - a stylized latent diffusion model.This model is intended to produce
 
 DDColor — AI image colorization for grayscale/B&W photos using dual decoders (ICCV 2023).
 
+| Input | Output |
+|---|---|
+| <img width="300" src="https://github.com/user-attachments/assets/051491a3-14c2-42af-9992-41c4238bcfd1"> | <img width="300" src="https://github.com/user-attachments/assets/ab1a8e3a-7b6c-4150-945b-6f94e4858ed7"> |
+
 | Download Link | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
 | [DDColor_Tiny.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/ddcolor-v1/DDColor_Tiny.mlpackage.zip) | 242 MB | 512×512 RGB | AB channels (LAB) | [piddnad/DDColor](https://github.com/piddnad/DDColor) | [Apache-2.0](https://github.com/piddnad/DDColor/blob/master/LICENSE) | 2023 | [DDColorDemo](sample_apps/DDColorDemo) | [convert_ddcolor.py](conversion_scripts/convert_ddcolor.py) |

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ You are free to do or not.
   - [Openjourney](#openjourney)
   - [dreamlike-photoreal-2.0](#dreamlike-photoreal-2)
 
+- [**Image Colorization**](#image-colorization)
+  - [DDColor Tiny](#ddcolor-tiny)
+
 - [**Face Recognition**](#face-recognition)
   - [AdaFace IR-18](#adaface-ir-18)
 
@@ -879,6 +882,16 @@ Pastel Mix - a stylized latent diffusion model.This model is intended to produce
 | Google Drive Link  | Original Model | License | Run on mac |Conversion Script |Year|
 | ------------- | ------------- | ------------- |  ------------- | ------------- | ------------- | 
 | [dreamlike-photoreal-2.0](https://drive.google.com/file/d/1D5RXYE52wyXPq6TdCHM8DIkP4dxHafwt/view?usp=share_link) |[dreamlike-art/dreamlike-photoreal-2.0](https://huggingface.co/dreamlike-art/dreamlike-photoreal-2.0)|[CreativeML OpenRAIL-M](https://huggingface.co/dreamlike-art/dreamlike-photoreal-2.0)|[godly-devotion/MochiDiffusion](https://github.com/godly-devotion/MochiDiffusion)|[godly-devotion/MochiDiffusion](https://github.com/godly-devotion/MochiDiffusion/wiki/How-to-convert-Stable-Diffusion-models-to-Core-ML#requirements) |2023|
+
+# Image Colorization
+
+### DDColor Tiny
+
+DDColor — AI image colorization for grayscale/B&W photos using dual decoders (ICCV 2023).
+
+| Download Link | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| [DDColor_Tiny.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/ddcolor-v1/DDColor_Tiny.mlpackage.zip) | 242 MB | 512×512 RGB | AB channels (LAB) | [piddnad/DDColor](https://github.com/piddnad/DDColor) | [Apache-2.0](https://github.com/piddnad/DDColor/blob/master/LICENSE) | 2023 | [DDColorDemo](sample_apps/DDColorDemo) | [convert_ddcolor.py](conversion_scripts/convert_ddcolor.py) |
 
 # Face Recognition
 

--- a/conversion_scripts/convert_ddcolor.py
+++ b/conversion_scripts/convert_ddcolor.py
@@ -1,0 +1,166 @@
+"""
+Convert DDColor Tiny image colorization model to CoreML.
+
+Hooks are replaced with explicit feature passing for correct tracing.
+coremltools _int op is monkey-patched to handle non-scalar arrays.
+"""
+
+import sys
+sys.path.insert(0, '/tmp/ddcolor_repo')
+
+import torch
+import torch.nn as nn
+import os
+import numpy as np
+
+
+class DDColorFlat(nn.Module):
+    """DDColor with hooks replaced by explicit feature passing."""
+
+    def __init__(self, ddcolor):
+        super().__init__()
+        # Encoder components
+        self.encoder_arch = ddcolor.encoder.arch
+        # Decoder components
+        self.decoder = ddcolor.decoder
+        # Refine
+        self.refine_net = ddcolor.refine_net
+        # Normalization buffers
+        self.register_buffer('mean', ddcolor.mean)
+        self.register_buffer('std', ddcolor.std)
+
+    def forward(self, x):
+        # Normalize input
+        x = (x - self.mean) / self.std
+
+        # Run ConvNeXt encoder and capture features at each stage
+        features = []
+        h = x
+        for i in range(4):
+            h = self.encoder_arch.downsample_layers[i](h)
+            h = self.encoder_arch.stages[i](h)
+            norm_layer = getattr(self.encoder_arch, f'norm{i}')
+            feat = norm_layer(h)
+            features.append(feat)
+
+        # Manually inject features into decoder hooks
+        for i, hook in enumerate(self.decoder.hooks):
+            hook.feature = features[i]
+
+        # Run decoder
+        out_feat = self.decoder()
+
+        # Refine
+        coarse_input = torch.cat([out_feat, x], dim=1)
+        out = self.refine_net(coarse_input)
+        return out
+
+
+def main():
+    import coremltools as ct
+    import coremltools.converters.mil.frontend.torch.ops as torch_ops
+    from coremltools.converters.mil import Builder as mb
+
+    # Monkey-patch _int handler for non-scalar arrays
+    def patched_cast(context, node, dtype, dtype_name):
+        inputs = torch_ops._get_inputs(context, node, expected=1)
+        x = inputs[0]
+        if x.val is not None:
+            val = x.val
+            if hasattr(val, 'item'):
+                try:
+                    val = val.item()
+                except (ValueError, RuntimeError):
+                    val = int(np.asarray(val).flat[0])
+            res = mb.const(val=dtype(val), name=node.name)
+            context.add(res)
+        else:
+            res = mb.cast(x=x, dtype=dtype_name, name=node.name)
+            context.add(res)
+    torch_ops._cast = patched_cast
+
+    from ddcolor.model import DDColor
+
+    print("Loading DDColor Tiny model...")
+    model = DDColor(
+        encoder_name='convnext-t',
+        decoder_name='MultiScaleColorDecoder',
+        input_size=[512, 512],
+        num_output_channels=2,
+        last_norm='Spectral',
+        do_normalize=False,
+        num_queries=100,
+        num_scales=3,
+        dec_layers=9,
+    )
+
+    hf_snapshots = os.path.expanduser(
+        "~/.cache/huggingface/hub/models--piddnad--ddcolor_paper_tiny/snapshots/")
+    snapshot = os.listdir(hf_snapshots)[0]
+    weights_path = os.path.join(hf_snapshots, snapshot, "pytorch_model.bin")
+    state = torch.load(weights_path, map_location="cpu", weights_only=True)
+    model.load_state_dict(state, strict=False)
+    model.eval()
+    print(f"Params: {sum(p.numel() for p in model.parameters()) / 1e6:.1f}M")
+
+    # Create flat model (no hooks for data flow)
+    flat = DDColorFlat(model)
+    flat.eval()
+
+    # Verify output matches original
+    dummy = torch.randn(1, 3, 512, 512)
+    with torch.no_grad():
+        out_orig = model(dummy)
+        out_flat = flat(dummy)
+    diff = (out_orig - out_flat).abs().max().item()
+    print(f"Flat vs original diff: {diff:.8f}")
+    print(f"Output shape: {out_flat.shape}")
+
+    # Trace
+    print("Tracing...")
+    with torch.no_grad():
+        traced = torch.jit.trace(flat, dummy, strict=False)
+
+    # Verify trace
+    with torch.no_grad():
+        out_traced = traced(dummy)
+    diff2 = (out_flat - out_traced).abs().max().item()
+    print(f"Trace verification diff: {diff2:.8f}")
+
+    # Second input to make sure it's not using cached values
+    dummy2 = torch.rand(1, 3, 512, 512)  # different input
+    with torch.no_grad():
+        out_flat2 = flat(dummy2)
+        out_traced2 = traced(dummy2)
+    diff3 = (out_flat2 - out_traced2).abs().max().item()
+    diff_inputs = (out_traced - out_traced2).abs().max().item()
+    print(f"Second input trace diff: {diff3:.8f}")
+    print(f"Different inputs produce different outputs: {diff_inputs > 0.01}")
+
+    # Convert
+    print("Converting to CoreML...")
+    mlmodel = ct.convert(
+        traced,
+        inputs=[ct.TensorType(name='image', shape=(1, 3, 512, 512))],
+        outputs=[ct.TensorType(name='ab_channels')],
+        minimum_deployment_target=ct.target.iOS16,
+        compute_precision=ct.precision.FLOAT32,
+    )
+
+    mlmodel.author = "CoreML-Models"
+    mlmodel.short_description = "DDColor Tiny: Image colorization. Input: 512x512 RGB [0,1]. Output: AB channels in LAB."
+    mlmodel.license = "Apache-2.0"
+
+    output_dir = os.path.join(os.path.dirname(__file__), "..",
+                               "sample_apps", "DDColorDemo", "DDColorDemo")
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, "DDColor_Tiny.mlpackage")
+    mlmodel.save(output_path)
+
+    size = sum(os.path.getsize(os.path.join(dp, f))
+               for dp, _, fns in os.walk(output_path) for f in fns) / 1e6
+    print(f"\nSaved to {output_path} ({size:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample_apps/DDColorDemo/DDColorDemo.xcodeproj/project.pbxproj
+++ b/sample_apps/DDColorDemo/DDColorDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,66 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D10000010000000000000001 /* DDColorDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000020000000000000001 /* DDColorDemoApp.swift */; };
+		D10000010000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000020000000000000002 /* ContentView.swift */; };
+		D10000010000000000000003 /* ImageColorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000020000000000000003 /* ImageColorizer.swift */; };
+		D10000010000000000000004 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D10000020000000000000004 /* Assets.xcassets */; };
+		D10000010000000000000006 /* DDColor_Tiny.mlpackage in Sources */ = {isa = PBXBuildFile; fileRef = D10000020000000000000006 /* DDColor_Tiny.mlpackage */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		D10000020000000000000001 /* DDColorDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDColorDemoApp.swift; sourceTree = "<group>"; };
+		D10000020000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D10000020000000000000003 /* ImageColorizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageColorizer.swift; sourceTree = "<group>"; };
+		D10000020000000000000004 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D10000020000000000000005 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D10000020000000000000006 /* DDColor_Tiny.mlpackage */ = {isa = PBXFileReference; lastKnownFileType = folder.mlpackage; path = DDColor_Tiny.mlpackage; sourceTree = "<group>"; };
+		D10000020000000000000010 /* DDColorDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DDColorDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D10000030000000000000001 /* Frameworks */ = { isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D10000040000000000000001 = { isa = PBXGroup; children = (D10000040000000000000002, D10000040000000000000003); sourceTree = "<group>"; };
+		D10000040000000000000002 /* DDColorDemo */ = { isa = PBXGroup; children = (D10000020000000000000001, D10000020000000000000002, D10000020000000000000003, D10000020000000000000006, D10000020000000000000004, D10000020000000000000005); path = DDColorDemo; sourceTree = "<group>"; };
+		D10000040000000000000003 /* Products */ = { isa = PBXGroup; children = (D10000020000000000000010); name = Products; sourceTree = "<group>"; };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D10000050000000000000001 /* DDColorDemo */ = { isa = PBXNativeTarget; buildConfigurationList = D10000070000000000000001; buildPhases = (D10000060000000000000001, D10000030000000000000001, D10000060000000000000002); buildRules = (); dependencies = (); name = DDColorDemo; productName = DDColorDemo; productReference = D10000020000000000000010; productType = "com.apple.product-type.application"; };
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D10000080000000000000001 /* Project object */ = { isa = PBXProject; attributes = { BuildIndependentTargetsInParallel = 1; LastSwiftUpdateCheck = 1500; LastUpgradeCheck = 1500; TargetAttributes = { D10000050000000000000001 = { CreatedOnToolsVersion = 15.0; }; }; }; buildConfigurationList = D10000070000000000000003; compatibilityVersion = "Xcode 14.0"; developmentRegion = en; hasScannedForEncodings = 0; knownRegions = (en, Base); mainGroup = D10000040000000000000001; productRefGroup = D10000040000000000000003; projectDirPath = ""; projectRoot = ""; targets = (D10000050000000000000001); };
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D10000060000000000000002 /* Resources */ = { isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (D10000010000000000000004); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D10000060000000000000001 /* Sources */ = { isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (D10000010000000000000006, D10000010000000000000001, D10000010000000000000002, D10000010000000000000003); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		D10000090000000000000001 /* Debug */ = { isa = XCBuildConfiguration; buildSettings = { ALWAYS_SEARCH_USER_PATHS = NO; ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES; CLANG_ANALYZER_NONNULL = YES; CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE; CLANG_CXX_LANGUAGE_STANDARD = "gnu++20"; CLANG_ENABLE_MODULES = YES; CLANG_ENABLE_OBJC_ARC = YES; CLANG_ENABLE_OBJC_WEAK = YES; CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES; CLANG_WARN_BOOL_CONVERSION = YES; CLANG_WARN_COMMA = YES; CLANG_WARN_CONSTANT_CONVERSION = YES; CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES; CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR; CLANG_WARN_DOCUMENTATION_COMMENTS = YES; CLANG_WARN_EMPTY_BODY = YES; CLANG_WARN_ENUM_CONVERSION = YES; CLANG_WARN_INFINITE_RECURSION = YES; CLANG_WARN_INT_CONVERSION = YES; CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES; CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES; CLANG_WARN_OBJC_LITERAL_CONVERSION = YES; CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR; CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES; CLANG_WARN_RANGE_LOOP_ANALYSIS = YES; CLANG_WARN_STRICT_PROTOTYPES = YES; CLANG_WARN_SUSPICIOUS_MOVE = YES; CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE; CLANG_WARN_UNREACHABLE_CODE = YES; CLANG_WARN__DUPLICATE_METHOD_MATCH = YES; COPY_PHASE_STRIP = NO; DEBUG_INFORMATION_FORMAT = dwarf; ENABLE_STRICT_OBJC_MSGSEND = YES; ENABLE_TESTABILITY = YES; ENABLE_USER_SCRIPT_SANDBOXING = YES; GCC_C_LANGUAGE_STANDARD = gnu17; GCC_DYNAMIC_NO_PIC = NO; GCC_NO_COMMON_BLOCKS = YES; GCC_OPTIMIZATION_LEVEL = 0; GCC_PREPROCESSOR_DEFINITIONS = ("DEBUG=1", "$(inherited)"); GCC_WARN_64_TO_32_BIT_CONVERSION = YES; GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR; GCC_WARN_UNDECLARED_SELECTOR = YES; GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE; GCC_WARN_UNUSED_FUNCTION = YES; GCC_WARN_UNUSED_VARIABLE = YES; IPHONEOS_DEPLOYMENT_TARGET = 16.0; MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE; MTL_FAST_MATH = YES; ONLY_ACTIVE_ARCH = YES; SDKROOT = iphoneos; SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)"; SWIFT_OPTIMIZATION_LEVEL = "-Onone"; }; name = Debug; };
+		D10000090000000000000002 /* Release */ = { isa = XCBuildConfiguration; buildSettings = { ALWAYS_SEARCH_USER_PATHS = NO; ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES; CLANG_ANALYZER_NONNULL = YES; CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE; CLANG_CXX_LANGUAGE_STANDARD = "gnu++20"; CLANG_ENABLE_MODULES = YES; CLANG_ENABLE_OBJC_ARC = YES; CLANG_ENABLE_OBJC_WEAK = YES; CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES; CLANG_WARN_BOOL_CONVERSION = YES; CLANG_WARN_COMMA = YES; CLANG_WARN_CONSTANT_CONVERSION = YES; CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES; CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR; CLANG_WARN_DOCUMENTATION_COMMENTS = YES; CLANG_WARN_EMPTY_BODY = YES; CLANG_WARN_ENUM_CONVERSION = YES; CLANG_WARN_INFINITE_RECURSION = YES; CLANG_WARN_INT_CONVERSION = YES; CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES; CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES; CLANG_WARN_OBJC_LITERAL_CONVERSION = YES; CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR; CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES; CLANG_WARN_RANGE_LOOP_ANALYSIS = YES; CLANG_WARN_STRICT_PROTOTYPES = YES; CLANG_WARN_SUSPICIOUS_MOVE = YES; CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE; CLANG_WARN_UNREACHABLE_CODE = YES; CLANG_WARN__DUPLICATE_METHOD_MATCH = YES; COPY_PHASE_STRIP = NO; DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"; ENABLE_NS_ASSERTIONS = NO; ENABLE_STRICT_OBJC_MSGSEND = YES; ENABLE_USER_SCRIPT_SANDBOXING = YES; GCC_C_LANGUAGE_STANDARD = gnu17; GCC_NO_COMMON_BLOCKS = YES; GCC_WARN_64_TO_32_BIT_CONVERSION = YES; GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR; GCC_WARN_UNDECLARED_SELECTOR = YES; GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE; GCC_WARN_UNUSED_FUNCTION = YES; GCC_WARN_UNUSED_VARIABLE = YES; IPHONEOS_DEPLOYMENT_TARGET = 16.0; MTL_ENABLE_DEBUG_INFO = NO; MTL_FAST_MATH = YES; SDKROOT = iphoneos; SWIFT_COMPILATION_MODE = wholemodule; VALIDATE_PRODUCT = YES; }; name = Release; };
+		D10000090000000000000003 /* Debug */ = { isa = XCBuildConfiguration; buildSettings = { ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon; ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor; CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; DEVELOPMENT_TEAM = MFN25KNUGJ; ENABLE_PREVIEWS = YES; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_FILE = DDColorDemo/Info.plist; INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES; INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES; INFOPLIST_KEY_UILaunchScreen_Generation = YES; INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"; INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait"; LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks"); MARKETING_VERSION = 1.0; PRODUCT_BUNDLE_IDENTIFIER = "com.coreml-models.ddcolordemo"; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_EMIT_LOC_STRINGS = YES; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = "1,2"; }; name = Debug; };
+		D10000090000000000000004 /* Release */ = { isa = XCBuildConfiguration; buildSettings = { ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon; ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor; CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; DEVELOPMENT_TEAM = MFN25KNUGJ; ENABLE_PREVIEWS = YES; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_FILE = DDColorDemo/Info.plist; INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES; INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES; INFOPLIST_KEY_UILaunchScreen_Generation = YES; INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"; INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait"; LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks"); MARKETING_VERSION = 1.0; PRODUCT_BUNDLE_IDENTIFIER = "com.coreml-models.ddcolordemo"; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_EMIT_LOC_STRINGS = YES; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = "1,2"; }; name = Release; };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D10000070000000000000001 = { isa = XCConfigurationList; buildConfigurations = (D10000090000000000000003, D10000090000000000000004); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		D10000070000000000000003 = { isa = XCConfigurationList; buildConfigurations = (D10000090000000000000001, D10000090000000000000002); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+/* End XCConfigurationList section */
+	};
+	rootObject = D10000080000000000000001 /* Project object */;
+}

--- a/sample_apps/DDColorDemo/DDColorDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/sample_apps/DDColorDemo/DDColorDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/DDColorDemo/DDColorDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/sample_apps/DDColorDemo/DDColorDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/DDColorDemo/DDColorDemo/Assets.xcassets/Contents.json
+++ b/sample_apps/DDColorDemo/DDColorDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/DDColorDemo/DDColorDemo/ContentView.swift
+++ b/sample_apps/DDColorDemo/DDColorDemo/ContentView.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+import PhotosUI
+
+struct ContentView: View {
+    @StateObject private var colorizer = ImageColorizer()
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var originalImage: UIImage?
+    @State private var colorizedImage: UIImage?
+    @State private var isProcessing = false
+    @State private var showOriginal = false
+    @State private var status = ""
+    @State private var processingTime: Double?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Status bar
+                HStack {
+                    Circle().fill(colorizer.isReady ? .green : .red).frame(width: 8, height: 8)
+                    Text(colorizer.isReady ? "Ready" : "Loading model...")
+                        .font(.caption).foregroundColor(.secondary)
+                    Spacer()
+                    if let t = processingTime {
+                        Text(String(format: "%.1fs", t))
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 4)
+
+                // Image display
+                GeometryReader { geo in
+                    if let colorized = colorizedImage, let original = originalImage {
+                        ZStack {
+                            Image(uiImage: showOriginal ? original : colorized)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { _ in showOriginal = true }
+                                .onEnded { _ in showOriginal = false }
+                        )
+                        .overlay(alignment: .bottom) {
+                            Text(showOriginal ? "Original" : "Colorized")
+                                .font(.caption).bold()
+                                .padding(.horizontal, 12).padding(.vertical, 4)
+                                .background(.ultraThinMaterial)
+                                .cornerRadius(8)
+                                .padding(.bottom, 8)
+                        }
+                    } else if let original = originalImage {
+                        Image(uiImage: original)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        VStack(spacing: 12) {
+                            Image(systemName: "photo.on.rectangle.angled")
+                                .font(.system(size: 60))
+                                .foregroundColor(.secondary)
+                            Text("Select a black & white photo")
+                                .foregroundColor(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                }
+
+                // Controls
+                VStack(spacing: 12) {
+                    if isProcessing {
+                        ProgressView(status)
+                    }
+
+                    HStack(spacing: 16) {
+                        PhotosPicker(selection: $selectedItem, matching: .images) {
+                            Label("Select Photo", systemImage: "photo.badge.plus")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+
+                        if let original = originalImage {
+                            Button {
+                                colorize(original)
+                            } label: {
+                                Label("Colorize", systemImage: "paintpalette.fill")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.orange)
+                            .disabled(isProcessing || !colorizer.isReady)
+                        }
+                    }
+
+                    if let colorized = colorizedImage {
+                        HStack(spacing: 16) {
+                            ShareLink(item: Image(uiImage: colorized),
+                                      preview: SharePreview("Colorized Image", image: Image(uiImage: colorized))) {
+                                Label("Share", systemImage: "square.and.arrow.up")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.bordered)
+
+                            Button {
+                                UIImageWriteToSavedPhotosAlbum(colorized, nil, nil, nil)
+                                status = "Saved to Photos"
+                            } label: {
+                                Label("Save", systemImage: "square.and.arrow.down")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("DDColor")
+            .onChange(of: selectedItem) { _ in loadImage() }
+        }
+    }
+
+    private func loadImage() {
+        guard let item = selectedItem else { return }
+        colorizedImage = nil
+        processingTime = nil
+        status = ""
+        Task {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let img = UIImage(data: data) {
+                originalImage = img
+            }
+        }
+    }
+
+    private func colorize(_ image: UIImage) {
+        isProcessing = true
+        status = "Colorizing..."
+        colorizedImage = nil
+        processingTime = nil
+        Task {
+            let start = CFAbsoluteTimeGetCurrent()
+            do {
+                let result = try await colorizer.colorize(image: image)
+                let elapsed = CFAbsoluteTimeGetCurrent() - start
+                await MainActor.run {
+                    colorizedImage = result
+                    processingTime = elapsed
+                    status = ""
+                    isProcessing = false
+                }
+            } catch {
+                await MainActor.run {
+                    status = "Error: \(error.localizedDescription)"
+                    isProcessing = false
+                }
+            }
+        }
+    }
+}

--- a/sample_apps/DDColorDemo/DDColorDemo/DDColorDemoApp.swift
+++ b/sample_apps/DDColorDemo/DDColorDemo/DDColorDemoApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct DDColorDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/sample_apps/DDColorDemo/DDColorDemo/ImageColorizer.swift
+++ b/sample_apps/DDColorDemo/DDColorDemo/ImageColorizer.swift
@@ -1,0 +1,288 @@
+import CoreML
+import UIKit
+import Accelerate
+
+class ImageColorizer: ObservableObject {
+    private var mlModel: MLModel?
+    @Published var isReady = false
+
+    init() {
+        loadModel()
+    }
+
+    private func loadModel() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self, let resourcePath = Bundle.main.resourcePath else { return }
+            let fm = FileManager.default
+            guard let items = try? fm.contentsOfDirectory(atPath: resourcePath) else { return }
+            let config = MLModelConfiguration()
+            config.computeUnits = .all
+            for item in items where item.hasSuffix(".mlmodelc") && item.contains("DDColor") {
+                let url = URL(fileURLWithPath: (resourcePath as NSString).appendingPathComponent(item))
+                if let model = try? MLModel(contentsOf: url, configuration: config) {
+                    self.mlModel = model
+                    DispatchQueue.main.async { self.isReady = true }
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - Colorize
+
+    func colorize(image: UIImage) async throws -> UIImage {
+        let fixed = image.normalizedOrientation()
+        guard let cgImage = fixed.cgImage else { throw ColorizerError.invalidImage }
+        let origW = cgImage.width
+        let origH = cgImage.height
+
+        // 1. Extract L channel at original resolution
+        let origLAB = rgbToLAB(cgImage: cgImage)
+        let origL = extractL(lab: origLAB, width: origW, height: origH)
+
+        // 2. Resize to 512x512 and create gray-RGB input
+        let resized = resizeCGImage(cgImage, to: CGSize(width: 512, height: 512))
+        let grayRGB = createGrayRGB(cgImage: resized)
+
+        // 3. Run model
+        guard let model = mlModel else { throw ColorizerError.modelNotLoaded }
+        let inputArray = try MLMultiArray(shape: [1, 3, 512, 512], dataType: .float32)
+        for i in 0..<(3 * 512 * 512) {
+            inputArray[i] = NSNumber(value: grayRGB[i])
+        }
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "image": MLFeatureValue(multiArray: inputArray)
+        ])
+        let output = try model.prediction(from: input)
+        guard let abArray = output.featureValue(for: "ab_channels")?.multiArrayValue else {
+            throw ColorizerError.predictionFailed
+        }
+
+        // 4. Extract AB, resize to original size
+        let abCount = abArray.count  // 1 * 2 * 512 * 512
+        var ab512 = [Float](repeating: 0, count: abCount)
+        for i in 0..<abCount { ab512[i] = abArray[i].floatValue }
+
+        // Debug: check AB range
+        let abMin = ab512.min() ?? 0
+        let abMax = ab512.max() ?? 0
+        print("[DDColor] AB range: [\(abMin), \(abMax)], count: \(abCount)")
+
+        let abOrig = resizeAB(ab512, fromW: 512, fromH: 512, toW: origW, toH: origH)
+
+        // 5. Combine L + AB → LAB → RGB
+        let colorImage = labToRGB(l: origL, ab: abOrig, width: origW, height: origH)
+        return colorImage
+    }
+
+    // MARK: - LAB Color Space
+
+    private func rgbToLAB(cgImage: CGImage) -> [Float] {
+        let w = cgImage.width, h = cgImage.height
+        let pixels = extractRGBPixels(cgImage: cgImage)
+
+        var lab = [Float](repeating: 0, count: w * h * 3)
+        for i in 0..<(w * h) {
+            let r = pixels[i * 3], g = pixels[i * 3 + 1], b = pixels[i * 3 + 2]
+            let (l, a, bv) = srgbToLab(r: r, g: g, b: b)
+            lab[i * 3] = l
+            lab[i * 3 + 1] = a
+            lab[i * 3 + 2] = bv
+        }
+        return lab
+    }
+
+    private func extractL(lab: [Float], width: Int, height: Int) -> [Float] {
+        var l = [Float](repeating: 0, count: width * height)
+        for i in 0..<(width * height) {
+            l[i] = lab[i * 3]
+        }
+        return l
+    }
+
+    private func createGrayRGB(cgImage: CGImage) -> [Float] {
+        // Convert to grayscale LAB [L, 0, 0] then back to RGB → model input
+        let w = cgImage.width, h = cgImage.height
+        let pixels = extractRGBPixels(cgImage: cgImage)
+
+        // [CHW] format: [1, 3, 512, 512], normalized to [0, 1]
+        var result = [Float](repeating: 0, count: 3 * w * h)
+        for i in 0..<(w * h) {
+            let r = pixels[i * 3], g = pixels[i * 3 + 1], b = pixels[i * 3 + 2]
+            let (l, _, _) = srgbToLab(r: r, g: g, b: b)
+            // LAB with A=0, B=0 → RGB
+            let (gr, gg, gb) = labToSrgb(l: l, a: 0, b: 0)
+            result[0 * w * h + i] = gr  // R channel
+            result[1 * w * h + i] = gg  // G channel
+            result[2 * w * h + i] = gb  // B channel
+        }
+        return result
+    }
+
+    private func labToRGB(l: [Float], ab: [Float], width: Int, height: Int) -> UIImage {
+        let count = width * height
+        var pixelData = [UInt8](repeating: 255, count: count * 4)
+
+        for i in 0..<count {
+            let lv = l[i]
+            let a = ab[i]
+            let b = ab[count + i]
+            let (r, g, bv) = labToSrgb(l: lv, a: a, b: b)
+            pixelData[i * 4] = UInt8(clamping: Int(r * 255))
+            pixelData[i * 4 + 1] = UInt8(clamping: Int(g * 255))
+            pixelData[i * 4 + 2] = UInt8(clamping: Int(bv * 255))
+            pixelData[i * 4 + 3] = 255
+        }
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: &pixelData, width: width, height: height,
+                            bitsPerComponent: 8, bytesPerRow: width * 4,
+                            space: colorSpace,
+                            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        let cgImg = ctx.makeImage()!
+        return UIImage(cgImage: cgImg)
+    }
+
+    // MARK: - sRGB ↔ LAB conversions (D65 illuminant)
+
+    private func srgbToLab(r: Float, g: Float, b: Float) -> (Float, Float, Float) {
+        // sRGB → linear
+        func toLinear(_ c: Float) -> Float {
+            c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+        }
+        let rl = toLinear(r), gl = toLinear(g), bl = toLinear(b)
+
+        // Linear RGB → XYZ (D65)
+        var x = rl * 0.4124564 + gl * 0.3575761 + bl * 0.1804375
+        var y = rl * 0.2126729 + gl * 0.7151522 + bl * 0.0721750
+        var z = rl * 0.0193339 + gl * 0.1191920 + bl * 0.9503041
+
+        // Normalize by D65 white point
+        x /= 0.95047; y /= 1.0; z /= 1.08883
+
+        func f(_ t: Float) -> Float {
+            t > 0.008856 ? pow(t, 1.0 / 3.0) : 7.787 * t + 16.0 / 116.0
+        }
+        let fx = f(x), fy = f(y), fz = f(z)
+
+        let l = 116.0 * fy - 16.0  // [0, 100]
+        let a = 500.0 * (fx - fy)  // [-128, 127]
+        let bv = 200.0 * (fy - fz) // [-128, 127]
+        return (l, a, bv)
+    }
+
+    private func labToSrgb(l: Float, a: Float, b: Float) -> (Float, Float, Float) {
+        let fy = (l + 16.0) / 116.0
+        let fx = a / 500.0 + fy
+        let fz = fy - b / 200.0
+
+        func invF(_ t: Float) -> Float {
+            let t3 = t * t * t
+            return t3 > 0.008856 ? t3 : (t - 16.0 / 116.0) / 7.787
+        }
+        let x = invF(fx) * 0.95047
+        let y = invF(fy) * 1.0
+        let z = invF(fz) * 1.08883
+
+        // XYZ → linear RGB
+        var r = x *  3.2404542 + y * -1.5371385 + z * -0.4985314
+        var g = x * -0.9692660 + y *  1.8760108 + z *  0.0415560
+        var bv = x *  0.0556434 + y * -0.2040259 + z *  1.0572252
+
+        // Linear → sRGB
+        func toSRGB(_ c: Float) -> Float {
+            let clamped = max(0, min(1, c))
+            return clamped <= 0.0031308 ? clamped * 12.92 : 1.055 * pow(clamped, 1.0 / 2.4) - 0.055
+        }
+        return (toSRGB(r), toSRGB(g), toSRGB(bv))
+    }
+
+    // MARK: - Image helpers
+
+    private func extractRGBPixels(cgImage: CGImage) -> [Float] {
+        let w = cgImage.width, h = cgImage.height
+        var pixelData = [UInt8](repeating: 0, count: w * h * 4)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: &pixelData, width: w, height: h,
+                            bitsPerComponent: 8, bytesPerRow: w * 4,
+                            space: colorSpace,
+                            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: w, height: h))
+
+        var result = [Float](repeating: 0, count: w * h * 3)
+        for i in 0..<(w * h) {
+            result[i * 3] = Float(pixelData[i * 4]) / 255.0
+            result[i * 3 + 1] = Float(pixelData[i * 4 + 1]) / 255.0
+            result[i * 3 + 2] = Float(pixelData[i * 4 + 2]) / 255.0
+        }
+        return result
+    }
+
+    private func resizeCGImage(_ image: CGImage, to size: CGSize) -> CGImage {
+        let w = Int(size.width), h = Int(size.height)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: nil, width: w, height: h,
+                            bitsPerComponent: 8, bytesPerRow: w * 4,
+                            space: colorSpace,
+                            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        ctx.interpolationQuality = .high
+        ctx.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+        return ctx.makeImage()!
+    }
+
+    private func resizeAB(_ ab: [Float], fromW: Int, fromH: Int, toW: Int, toH: Int) -> [Float] {
+        // ab is [2, fromH, fromW], resize each channel with bilinear interpolation
+        let fromCount = fromW * fromH
+        let toCount = toW * toH
+        var result = [Float](repeating: 0, count: 2 * toCount)
+
+        for ch in 0..<2 {
+            let srcOffset = ch * fromCount
+            let dstOffset = ch * toCount
+            for y in 0..<toH {
+                let srcY = Float(y) * Float(fromH) / Float(toH)
+                let y0 = min(Int(srcY), fromH - 1)
+                let y1 = min(y0 + 1, fromH - 1)
+                let fy = srcY - Float(y0)
+                for x in 0..<toW {
+                    let srcX = Float(x) * Float(fromW) / Float(toW)
+                    let x0 = min(Int(srcX), fromW - 1)
+                    let x1 = min(x0 + 1, fromW - 1)
+                    let fx = srcX - Float(x0)
+
+                    let v00 = ab[srcOffset + y0 * fromW + x0]
+                    let v10 = ab[srcOffset + y0 * fromW + x1]
+                    let v01 = ab[srcOffset + y1 * fromW + x0]
+                    let v11 = ab[srcOffset + y1 * fromW + x1]
+
+                    let v = v00 * (1 - fx) * (1 - fy) + v10 * fx * (1 - fy) +
+                            v01 * (1 - fx) * fy + v11 * fx * fy
+                    result[dstOffset + y * toW + x] = v
+                }
+            }
+        }
+        return result
+    }
+}
+
+extension UIImage {
+    func normalizedOrientation() -> UIImage {
+        guard imageOrientation != .up else { return self }
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        draw(in: CGRect(origin: .zero, size: size))
+        let normalized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return normalized ?? self
+    }
+}
+
+enum ColorizerError: LocalizedError {
+    case invalidImage, modelNotLoaded, predictionFailed
+    var errorDescription: String? {
+        switch self {
+        case .invalidImage: return "Invalid image"
+        case .modelNotLoaded: return "Model not loaded"
+        case .predictionFailed: return "Colorization failed"
+        }
+    }
+}

--- a/sample_apps/DDColorDemo/DDColorDemo/Info.plist
+++ b/sample_apps/DDColorDemo/DDColorDemo/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
## Summary
- Add DDColor Tiny (ConvNeXt-T) image colorization demo app
- Model (242MB) uploaded as release asset: [ddcolor-v1](https://github.com/john-rocky/CoreML-Models/releases/tag/ddcolor-v1)
- Includes conversion script with coremltools Transformer int-op patch

## Model
- **Input**: 512×512 RGB (grayscale converted to pseudo-RGB via LAB)
- **Output**: [1, 2, 512, 512] AB channels in LAB color space
- **Architecture**: ConvNeXt-T encoder + Transformer color decoder (55M params)
- **Precision**: Float32 (required for Transformer attention stability)
- **License**: Apache-2.0

## Features
- Select any B&W photo and colorize with one tap
- Long-press to toggle between original and colorized (Before/After)
- Save to Photos / Share
- Full LAB color space conversion in Swift (sRGB↔XYZ↔LAB)

## Test plan
- [ ] Download model from release, place in `DDColorDemo/DDColorDemo/`
- [ ] Select a grayscale photo and tap Colorize
- [ ] Verify colors appear natural
- [ ] Long-press to compare original vs colorized