### PR TITLE
Move per-model conversion notes from README to app READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,13 +496,7 @@ The sample app uses Vision's `VNGeneratePersonSegmentationRequest` to bootstrap 
 | ------------- | ---- | ----- | ------ | ---------------- | ------- | ---- | -------------- | ----------------- |
 | MatAnyone (5 mlpackages, ~111 MB FP16 total) | 111 MB | image [1,3,432,768] (per-frame state in Swift) | alpha matte [1,1,432,768] | [pq-yang/MatAnyone](https://github.com/pq-yang/MatAnyone) | [NTU S-Lab 1.0](https://github.com/pq-yang/MatAnyone/blob/main/LICENSE) | 2025 | [MatAnyoneDemo](sample_apps/MatAnyoneDemo) | [convert_matanyone.py](conversion_scripts/convert_matanyone.py) |
 
-**Conversion notes:**
-- Network split into 5 mlpackages: `encoder` (multi-scale features + key/shrinkage/selection), `mask_encoder`, `read_first` (first-frame readout, no memory attention), `read` (memory attention readout over a fixed-T ring buffer), and `decoder` (alpha matte head).
-- Memory carried in Swift between frames: sensory, last_mask, last_pix_feat, last_msk_value, accumulated obj_memory, plus a fixed `(T_max=5)` ring buffer of working-memory keys/shrinkages/values with a per-slot validity mask.
-- `single_object=False` but hard-coded `num_objects=1` lets the chunk loops collapse to a fast path; `flip_aug=False`, `use_long_term=False`, `chunk_size=-1` match the official matting config.
-- `torch.prod(1-mask, dim=1)` in `aggregate` is monkey-patched to `1-mask` (identity for `num_objects=1`) since `prod` isn't supported by coremltools.
-- Memory tensors are pre-flattened to rank 3 (`[1, C, T*h*w]`) to stay within Core ML's rank-5 limit; the variable-length working memory is handled by adding `(1-valid)*-6e4` to the similarity before top-k softmax (FP16-safe -inf substitute).
-- Resolution fixed at 768×432 (mobile 16:9, divisible by 16). For other aspect ratios re-run the converter with `--height/--width`.
+See [`sample_apps/MatAnyoneDemo/README.md`](sample_apps/MatAnyoneDemo/README.md) for the per-frame state machine, the 5-module split, and conversion details.
 
 # Super Resolution
 
@@ -657,14 +651,7 @@ Pytorch implementation of "Unsupervised Degradation Representation Learning for 
 | [SinSR_Denoiser.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/sinsr-v1/SinSR_Denoiser.mlpackage.zip) | 420 MB | input [1,6,256,256] | predicted_latent [1,3,256,256] | | | | | |
 | [SinSR_Decoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/sinsr-v1/SinSR_Decoder.mlpackage.zip) | 58 MB | latent [1,3,256,256] | image [1,3,1024,1024] | | | | | |
 
-**Conversion notes:**
-- Swin Transformer requires several patches for CoreML tracing: (1) pre-compute relative position bias as buffers, (2) replace `torch.roll` with slice+concat, (3) rewrite attention mask creation to avoid `__setitem__`, (4) patch coremltools `int` op converter for multi-dim tensor shape casts.
-- VQ-VAE decoder includes vector quantization (8192-entry codebook, argmin nearest-neighbor lookup) inside the CoreML model.
-- Denoiser input is 6-channel concat of `[scaled_noisy_latent, lq_image]` with baked-in timestep (always t=14 for single-step).
-- **Denoiser must use FP32 precision** — FP16 causes color shift (pinkish tint) in the Swin Transformer attention layers. Encoder/Decoder use FP16.
-- **Denoiser should use `cpuOnly`** compute units for best accuracy.
-- Swift orchestration handles noise injection, scaling (kappa=2.0, normalizeStd=2.218), and latent space encoding/decoding.
-- The model produces slight color shifts from the original image — this is inherent to SinSR's single-step distilled architecture, not a conversion artifact.
+See [`sample_apps/SinSRDemo/README.md`](sample_apps/SinSRDemo/README.md) for the inference pipeline and conversion details.
 
 
 # Low Light Enhancement
@@ -917,13 +904,7 @@ Towards Robust Monocular Depth Estimation: Mixing Datasets for Zero-shot Cross-d
 | [HyperSDUnetChunk2.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/hypersd-v1/HyperSDUnetChunk2.mlpackage.zip) | 299 MB | first half outputs + skip connections | noise_pred [2,4,64,64] | | | | | |
 | [HyperSDVAEDecoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/hypersd-v1/HyperSDVAEDecoder.mlpackage.zip) | 95 MB | latent [1,4,64,64] | image [1,3,512,512] | | | | | |
 
-**Conversion notes:**
-- Hyper-SD 1-step LoRA fused into SD1.5 base model with `pipe.fuse_lora()` before CoreML conversion.
-- Apple `ml-stable-diffusion` (`torch2coreml`) used with `--attention-implementation SPLIT_EINSUM` and `--chunk-unet` for Neural Engine deployment and memory-efficient inference.
-- 6-bit kmeans palettization on UNet only (TextEncoder FP16 contains inf values that break kmeans).
-- UNet must be quantized AFTER chunking — Apple's tool quantizes the unchunked model so chunks must be re-palettized separately.
-- coremltools 9.0 patches required: custom `int` op converter for multi-dim tensor shapes, `list(block.operations)` for `chunk_mlprogram.py` (CacheDoublyLinkedList API change).
-- Inference uses **TCD scheduler** (custom Swift implementation) with `guidance_scale=1.0` (no CFG amplification, single-step).
+See [`sample_apps/HyperSDDemo/README.md`](sample_apps/HyperSDDemo/README.md) for the LoRA fusion, chunked-UNet palettization, and TCD scheduler details.
 
 ### [stable-diffusion-v1-5](https://drive.google.com/file/d/1dqYEdhSPi7y0Dgans-Fk7_ViNviUTUJj/view?usp=share_link)
 
@@ -1094,22 +1075,7 @@ Google SigLIP — sigmoid-based contrastive image-text model for zero-shot class
 | [Kokoro_Decoder_256.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/kokoro-v1/Kokoro_Decoder_256.mlpackage.zip) | 241 MB | en_aligned [1, 640, 256] + asr_aligned [1, 512, 256] + ref_s [1, 256] | audio [1, 153600] @ 24kHz | | | | | |
 | [Kokoro_Decoder_512.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/kokoro-v1/Kokoro_Decoder_512.mlpackage.zip) | 246 MB | en_aligned [1, 640, 512] + asr_aligned [1, 512, 512] + ref_s [1, 256] | audio [1, 307200] @ 24kHz | | | | | |
 
-**On-device G2P (no external dependencies):**
-- **English**: lexicon-based (`us_gold` 90k entries + `us_silver` fallback) with possessive splitting, acronym detection, and a rule-based grapheme→phoneme fallback for OOV. ~6 MB of bundled JSON. No MLX, no Python.
-- **Japanese**: Apple's `CFStringTokenizer` (ja_JP locale) gives romaji per token; `Latin-Hiragana` ICU transform converts to hiragana; a ported subset of misaki's `cutlet.HEPBURN` IPA table + context rules (long vowels, ん assimilation, particles は→βa / へ→e) emits Kokoro-compatible phonemes. **No MeCab, no IPADic, ~zero overhead.**
-
-**Conversion notes:**
-- The Predictor uses `RangeDim` for flexible phoneme length (1–256 incl. BOS/EOS), so the bidirectional LSTM never sees padding.
-- The Decoder uses fixed-shape buckets because its iSTFTNet vocoder + InstanceNorm + bidirectional LSTM are length-sensitive — padding inside one bucket only causes a phase shift (spec corr 0.93 vs unpadded reference) which is perceptually inaudible. Smaller padding ratio = cleaner output, hence multiple buckets.
-- **Critical bug fix**: CoreML's `mod` op silently produces wrong values for `(float / scalar) % 1` (e.g., in the SineGen of iSTFTNet). Output spec correlation drops to 0.67 vs PyTorch. Replacing `(f0 / sr) % 1` with `(f0/sr) - floor(f0/sr)` brings it to **0.996**. See [conversion_scripts/convert_kokoro.py](conversion_scripts/convert_kokoro.py) and the patched `kokoro/istftnet.py`.
-- `pack_padded_sequence` and `pad_packed_sequence` are bypassed in the predictor's TextEncoder and DurationEncoder LSTMs (CoreML incompatible) — the LSTM runs on the unpadded tensor directly via `RangeDim`.
-- The decoder converts at FP32 (`compute_precision=ct.precision.FLOAT32`); FP16 corrupts audio quality.
-- Random noise generators (`torch.randn_like` in SineGen and SourceModuleHnNSF) are zeroed before tracing so the CoreML model is deterministic and matches PyTorch bit-for-bit.
-- The decoder vocoder runs efficiently on Neural Engine — first inference ~700ms, subsequent inferences ~200ms on iPhone (warm cache).
-
-**Voices included** in the demo (all 510×256 style tensors, ~512KB each):
-- English (5): `af_heart`, `af_bella`, `am_michael`, `bf_emma`, `bm_george`
-- Japanese (5): `jf_alpha`, `jf_gongitsune`, `jm_kumo`, `jf_nezumi`, `jf_tebukuro`
+See [`sample_apps/KokoroDemo/README.md`](sample_apps/KokoroDemo/README.md) for the on-device G2P (English + Japanese), bucketed decoder strategy, and conversion details.
 
 # Anomaly Detection
 
@@ -1135,10 +1101,7 @@ The first open-source iOS implementation. Loads any audio file, runs the CoreML 
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
 | [BasicPitch_nmp.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/basic-pitch-v1/BasicPitch_nmp.mlpackage.zip) | 272 KB | audio waveform [1, 43844, 1] @ 22050 Hz mono | note [1,172,88] + onset [1,172,88] + contour [1,172,264] | [spotify/basic-pitch](https://github.com/spotify/basic-pitch) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | 2022 | [BasicPitchDemo](sample_apps/BasicPitchDemo) |
 
-**Implementation notes:**
-- **MLMultiArray strides matter on ANE.** The Neural Engine returns the (1, 172, 88) output with stride `[16512, 96, 1]` — rows are padded from 88 to 96 columns for alignment. Reading `dataPointer` linearly gives garbage; you must use `array.strides` to skip the padding.
-- **MP3 decoder mismatch.** iOS Core Audio's MP3 decoder produces ~7% louder samples than librosa (sometimes exceeding ±1.0). Pass the same MP3 to Python and to the iOS app and you get different note detections from the same model. Fix: peak-normalize the loaded audio to 0.98 with `vDSP_maxmgv` before windowing.
-- **Algorithm port is exact.** Onset inference uses element-wise min across diff orders, the greedy tracker uses Python's `i -= k` rollback with `i < n_frames - 1` boundary, melodia trick zeroes energy in-place during forward/backward passes including the ±1 freq neighbors. With matching audio input the Swift output matches the Python reference note-for-note.
+See [`sample_apps/BasicPitchDemo/README.md`](sample_apps/BasicPitchDemo/README.md) for the sliding-window inference, post-processing port, and iOS-specific gotchas.
 
 # Text-to-Music Generation
 
@@ -1158,11 +1121,7 @@ The first open-source iOS implementation. Loads any audio file, runs the CoreML 
 | [StableAudioDiT_FP32.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/stable-audio-v1/StableAudioDiT_FP32.mlpackage.zip) | 1.3 GB | latent [1,64,256] + timestep + conditioning | velocity [1,64,256] | | | | | |
 | [StableAudioVAEDecoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/stable-audio-v1/StableAudioVAEDecoder.mlpackage.zip) | 149 MB | latent [1, 64, 256] | stereo audio [1, 2, 524288] at 44.1kHz | | | | | |
 
-**Conversion notes:**
-- DiT INT8 (`StableAudioDiT`): use with `cpuAndGPU`. Fastest, slight quality loss from quantization.
-- DiT FP32 (`StableAudioDiT_FP32`): use with `cpuOnly`. Best quality, slower (~1.3GB). FP16 weights overflow in attention on iOS GPU, so FP32 compute + CPU is required.
-- T5 INT8: may produce occasional NaN values — the sample app sanitizes these before passing to DiT.
-- VAE Decoder FP16: weight_norm must be removed before tracing (Snake activation).
+See [`sample_apps/StableAudioDemo/README.md`](sample_apps/StableAudioDemo/README.md) for INT8 vs FP32 DiT selection and conversion details.
 
 ## Models converted by someone other than me.
 

--- a/docs/coreml_conversion_notes.md
+++ b/docs/coreml_conversion_notes.md
@@ -181,6 +181,13 @@ Some PyTorch operations are not supported by coremltools and cause conversion fa
 | In-place tensor assign | `tensor[..., :n] = val` | Rewrite with `torch.where` or scatter |
 | `torch.nonzero` | Data-dependent indexing | Pre-compute outside model |
 | `torchvision::deform_conv2d` | BiRefNet, deformable attention | No workaround — use model variant without it |
+| `torch.prod` | MatAnyone `aggregate(prob, dim=1)` | For a singleton dim, replace with identity. General case: lower to a sequence of multiplications. |
+| `pack_padded_sequence` / `pad_packed_sequence` | Kokoro Predictor LSTMs | Run the LSTM on the unpadded tensor directly via `RangeDim`; the model never sees padding tokens. |
+| `tensor.float() % 1` (`mod` on float / scalar) | Kokoro iSTFTNet `SineGen` | CoreML's `mod` silently produces wrong values. Replace with `x - torch.floor(x)`. Spec corr 0.67 → 0.996. |
+| `torch.randn_like` etc. | Kokoro `SourceModuleHnNSF`, any "regularisation" noise | Replace with `zeros_like` before tracing — otherwise the converted model is non-deterministic and parity tests are meaningless. |
+| `torch.roll` | Swin Transformer shifted windows | Replace with `slice + concat`. |
+| In-place attention-mask construction | Swin Transformer | Build the mask functionally (e.g. via `torch.where` / arange comparisons); avoid `mask[a:b, c:d] = val`. |
+| `nn.utils.weight_norm` | Stable Audio Snake activations, etc. | Call `remove_weight_norm()` on the module before tracing. coremltools sees a much cleaner graph. |
 
 ---
 
@@ -290,3 +297,127 @@ Even with correct audio and correct MLMultiArray reads, the post-processing port
 - The melodia trick must zero out `remaining_energy[i, freq_idx]` and the `freq_idx ± 1` neighbors **inside** the forward/backward walks, not just at the end. Python's outer `while np.max > frame_thresh` loop relies on this in-place erasure to converge — without it the outer loop never makes progress and you end up needing an iteration cap.
 
 After porting these exactly, the Swift algorithm matches Python `output_to_notes_polyphonic` note-for-note when given identical model output.
+
+---
+
+## Tensor Rank Limits
+
+**Core ML supports tensor rank ≤ 5.** Anything higher fails at conversion time with an error like:
+
+```
+ValueError: Core ML only supports tensors with rank <= 5.
+Layer "cast_X", with type "cast", outputs a rank 6 tensor.
+```
+
+This typically bites video / multi-object models that carry both an "objects" and a "time" dimension on top of `(B, C, H, W)`.
+
+**Fix:** flatten one of the singleton dims at the IO boundary. For MatAnyone the working memory is stored as `(1, num_obj, C, T, h, w)` in PyTorch (rank 6). With `num_obj=1` hard-coded we can collapse it to `(1, C, T·h·w)` (rank 3) before passing it as a Core ML input, and reshape back inside the wrapper if needed.
+
+The general rule: pre-flatten any singleton dim and reshape back inside the model.
+
+---
+
+## FP16 Attention Overflow
+
+**Several attention architectures overflow when run at FP16, even on Apple Silicon GPU.**
+
+Symptoms:
+- **Swin Transformer (SinSR Denoiser)** — pinkish / wrong colour cast on the entire output.
+- **Stable Audio DiT** — NaNs in the velocity prediction.
+- Most softmax-based attention with large logits ranges.
+
+Diagnosis: convert with `compute_precision=ct.precision.FLOAT16`, run on the device, look at the first inference. If the output is wildly off but PyTorch is fine, FP16 overflow is the most likely culprit.
+
+Fixes (in order of preference):
+
+1. **Convert at FP32** with `compute_precision=ct.precision.FLOAT32` and run on `.cpuOnly`. Larger model (~2× FP16), slower than ANE / GPU, but correct.
+2. **INT8 quantize** the offending block and run it on `.cpuAndGPU`. Often works because INT8 dequantizes element-wise without the giant intermediate softmax tensor in FP16.
+3. **Per-block precision** — keep most of the model FP16 and override the precision for the specific submodule. Rarely worth the complexity.
+
+Don't try to "scale the logits down" inside the model — by the time you're running inference the conversion is already done.
+
+---
+
+## FP16-Safe Masked Softmax
+
+**`-1e9` overflows in FP16.** Anywhere you do `logits + (1 - valid_mask) * -1e9` to mask out positions before a softmax, the converted model will turn the masked positions into `-inf` and then `nan` after the softmax.
+
+Use `-6e4` (or even `-3e4`) instead. It's still smaller than any realistic similarity value but stays representable in FP16.
+
+```python
+masked = logits + (1.0 - valid) * -6.0e4
+attn = masked.softmax(dim=-1)
+```
+
+This applies to MatAnyone's working-memory attention, but the same trick is needed for any masked attention you convert.
+
+---
+
+## FP16 Feedback Loops Drift
+
+**Don't iterate the same input through a recurrent / feedback model more times than the Python reference does.**
+
+MatAnyone's official `process_video` runs the first frame 10 times with `first_frame_pred=True` to refine the memory. In the FP16 CoreML port, those 10 repeated passes drift the alpha matte to zero — the foreground disappears entirely.
+
+The PyTorch reference is FP32, which has enough headroom to absorb the iterative drift. A FP16 CoreML graph does not. **Replicate the official iteration count only when you've verified that each iteration is bit-stable in FP16.** Otherwise stick to the minimum number of passes (1 seed + 1 `first_frame_pred` is usually enough; the Python parity test should confirm).
+
+---
+
+## Swin Transformer Conversion Checklist
+
+Several models in this repo (SinSR, etc.) wrap a Swin Transformer that needs the same set of patches before it traces cleanly:
+
+1. **Pre-compute the relative-position bias as a `register_buffer`**, instead of building it from `arange` + `meshgrid` inside `forward`.
+2. **Replace `torch.roll`** with `slice + concat` along H and W (the shifted-window mechanism).
+3. **Rewrite the attention mask construction** to avoid `__setitem__` (no `mask[a:b, c:d] = val`). Build it functionally with `torch.where` / boolean arithmetic.
+4. **Patch the coremltools `int` op converter** to handle multi-dim tensor shape casts. The default converter only handles scalar shapes; Swin's window partitioning produces a 2-D shape that needs the patched op.
+
+A reference implementation is in [`conversion_scripts/convert_sinsr.py`](../conversion_scripts/convert_sinsr.py).
+
+---
+
+## Apple `ml-stable-diffusion` (`torch2coreml`) Gotchas
+
+When using Apple's `ml-stable-diffusion` toolchain (Hyper-SD, SD 1.5, etc.):
+
+- **Quantize after chunking, not before.** `torch2coreml` palettizes the unchunked model; once chunks are emitted by `chunk_mlprogram.py`, each chunk has to be re-palettized separately.
+- **6-bit kmeans palettization breaks on weights containing `inf`.** This is most common in CLIP-style text encoders. Quantize the UNet only and ship the text encoder at FP16.
+- **coremltools 9.0 patches** required for the toolchain itself:
+  - Custom `int` op converter for multi-dim tensor shape casts.
+  - `list(block.operations)` workaround in `chunk_mlprogram.py` for the new `CacheDoublyLinkedList` API.
+
+---
+
+## NaN Sanitisation Around INT8 Models
+
+Some INT8-quantized text/vision encoders (notably Stable Audio's T5) intermittently emit `NaN` values for specific token positions. The downstream model then poisons everything from that point on.
+
+**Mitigation:** sanitise on the Swift side before passing the embeddings to the next model.
+
+```swift
+for i in 0..<count {
+    let v = embeddings[i].floatValue
+    embeddings[i] = NSNumber(value: v.isNaN ? 0 : v)
+}
+```
+
+It's not a fix for the underlying issue (FP32 conversion of the same encoder is clean), but it keeps the pipeline running on devices where the INT8 path is the only one that fits in memory.
+
+---
+
+## MPS Slice on Singleton Dimension Crashes
+
+**Some Core ML graphs crash on iOS GPU with:**
+
+```
+[MPSNDArrayDescriptor sliceDimension:withSubrange:] error:
+subRange.start (18446744073709551615) is not less than length of dimension[1] (1)
+```
+
+`18446744073709551615` is `UINT64_MAX` — the result of casting `-1` to unsigned. It happens when an op slices a length-1 dimension with a negative index, and Metal Performance Shaders does not handle that case.
+
+This bites models with reshapes/slices over a singleton "num_objects" or "T" dimension (MatAnyone's `read_first` / `read` modules hit it because the QueryTransformer reshapes obj memory across the size-1 num_objects dim).
+
+**Fix:** load the offending model with `.cpuOnly`. The CPU path handles the slice correctly. The "real" fix is to drop the singleton dimension at the wrapper level before tracing, but that's a bigger refactor.
+
+---

--- a/sample_apps/BasicPitchDemo/README.md
+++ b/sample_apps/BasicPitchDemo/README.md
@@ -1,0 +1,45 @@
+# BasicPitchDemo
+
+Sample iOS app for [spotify/basic-pitch](https://github.com/spotify/basic-pitch) — polyphonic Automatic Music Transcription. Converts any audio (any instrument, any voice) into MIDI notes with pitch bend detection. Just **17 K parameters / 272 KB** — runs in real time on iPhone with full ANE acceleration.
+
+The first open-source iOS implementation. Loads any audio file, runs the CoreML model in 2-second sliding windows, then runs the full Python `note_creation.py` pipeline natively in Swift (onset inference, greedy backwards-in-time tracking, melodia trick, pitch bend extraction). Detected notes are visualised as a piano roll, exported as a Standard MIDI File, and played back through a built-in additive sine synth so you can A/B compare with the original audio.
+
+<video src="https://github.com/user-attachments/assets/d4e96b51-680f-471c-93d1-7546d5890cd7" width="400"></video>
+
+## Models
+
+| Model | Size | Input | Output |
+|-------|------|-------|--------|
+| [BasicPitch_nmp.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/basic-pitch-v1/BasicPitch_nmp.mlpackage.zip) | 272 KB | audio waveform [1, 43844, 1] @ 22050 Hz mono | note [1, 172, 88] + onset [1, 172, 88] + contour [1, 172, 264] |
+
+## Setup
+
+1. Download the `.mlpackage.zip` above
+2. Unzip and drag the `.mlpackage` into the Xcode project
+3. Build and run on a physical device (iOS 17+)
+
+## Pipeline
+
+```
+audio file ──→ AVAudioFile decode ──→ peak-normalize to 0.98 ──→ resample to 22050 Hz mono
+                                                                           │
+                                                          2-second sliding windows
+                                                                           │
+                                                                       BasicPitch
+                                                                           │
+                                                          (note, onset, contour)
+                                                                           │
+                                                              note_creation pipeline (Swift)
+                                                                           │
+                                                       MIDI notes + pitch bends
+                                                                           │
+                                                       piano-roll visual + .mid export + sine synth playback
+```
+
+## Implementation Notes (iOS-specific)
+
+- **MLMultiArray strides matter on ANE.** The Neural Engine returns the `(1, 172, 88)` output with stride `[16512, 96, 1]` — rows are padded from 88 to 96 columns for alignment. Reading `dataPointer` linearly gives garbage; use `array.strides` to skip the padding.
+- **MP3 decoder mismatch.** iOS Core Audio's MP3 decoder produces ~7% louder samples than librosa (sometimes exceeding ±1.0). The same MP3 fed to Python and to the iOS app yields different note detections from the same model. Fix: peak-normalise the loaded audio to 0.98 with `vDSP_maxmgv` before windowing.
+- **Algorithm port is exact.** Onset inference uses element-wise min across diff orders, the greedy tracker uses Python's `i -= k` rollback with `i < n_frames - 1` boundary, the melodia trick zeroes energy in-place during forward/backward passes including the `± 1` freq neighbours. With matching audio input the Swift output matches the Python reference note-for-note.
+
+A deeper dive into the post-processing port (greedy tracker rollback, melodia trick in-place zeroing, `min_note_len` boundary conditions) is in [`docs/coreml_conversion_notes.md`](../../docs/coreml_conversion_notes.md#music-transcription-basic-pitch--ios-pitfalls).

--- a/sample_apps/HyperSDDemo/README.md
+++ b/sample_apps/HyperSDDemo/README.md
@@ -1,0 +1,41 @@
+# HyperSDDemo
+
+Sample iOS app for [ByteDance/Hyper-SD](https://huggingface.co/ByteDance/Hyper-SD) — single-step text-to-image generation distilled from SD 1.5 via Trajectory Segmented Consistency Distillation. ByteDance reports 2× user preference vs. SD-Turbo at 1 step.
+
+<video src="https://github.com/user-attachments/assets/dd456c13-d778-4a84-8bb2-9dfd78de3070" width="400"></video>
+
+<img width="400" src="hypersd_demo.png">
+
+*1-step generations on iPhone, 512×512. Prompts: cat with sunglasses, cyberpunk city, japanese garden, astronaut on horse.*
+
+## Models
+
+4 CoreML models, ~947 MB total. CLIP text encoder + Swin-style chunked UNet (6-bit palettized) + VAE decoder. The TCD scheduler (custom Swift implementation) drives single-step inference.
+
+| Model | Size | Input | Output |
+|-------|------|-------|--------|
+| [HyperSDTextEncoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/hypersd-v1/HyperSDTextEncoder.mlpackage.zip) | 235 MB | input_ids [1,77] | encoder_hidden_states [1,77,768] |
+| [HyperSDUnetChunk1.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/hypersd-v1/HyperSDUnetChunk1.mlpackage.zip) | 318 MB | latent + encoder_hs + timestep | first half intermediates |
+| [HyperSDUnetChunk2.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/hypersd-v1/HyperSDUnetChunk2.mlpackage.zip) | 299 MB | first half outputs + skip connections | noise_pred [2,4,64,64] |
+| [HyperSDVAEDecoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/hypersd-v1/HyperSDVAEDecoder.mlpackage.zip) | 95 MB | latent [1,4,64,64] | image [1,3,512,512] |
+
+## Setup
+
+1. Download the four `.mlpackage.zip` files above
+2. Unzip and drag them into the Xcode project
+3. Build and run on iPhone 15 or newer (the chunked UNet expects ANE)
+
+## Conversion Notes
+
+- **LoRA fusion before conversion**. The Hyper-SD 1-step LoRA is fused into the SD 1.5 base model with `pipe.fuse_lora()` before handing the unified model to Apple's `ml-stable-diffusion`.
+- **Apple's `torch2coreml` toolchain** is invoked with `--attention-implementation SPLIT_EINSUM` (Neural Engine path) and `--chunk-unet` (memory-efficient inference). UNet is split across two mlpackages so each chunk fits ANE memory.
+- **6-bit kmeans palettization on UNet only**. The CLIP text encoder's FP16 weights contain `inf` values that break kmeans, so the text encoder ships at FP16 instead.
+- **Quantize after chunking, not before**. Apple's tool palettizes the unchunked model; once chunks are emitted, each chunk has to be re-palettized separately.
+- **coremltools 9.0 patches required**:
+  - Custom `int` op converter for multi-dim tensor shape casts
+  - `list(block.operations)` workaround in `chunk_mlprogram.py` for the new `CacheDoublyLinkedList` API
+- **Inference scheduler**. A custom Swift TCD scheduler implementation drives single-step inference with `guidance_scale=1.0` (no CFG amplification at 1 step).
+
+## Conversion Script
+
+[`conversion_scripts/convert_hypersd.py`](../../conversion_scripts/convert_hypersd.py)

--- a/sample_apps/KokoroDemo/README.md
+++ b/sample_apps/KokoroDemo/README.md
@@ -1,0 +1,48 @@
+# KokoroDemo
+
+Sample iOS app for [hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) — open-weight 82M-parameter TTS using a style-conditioned StyleTTS2 architecture (BERT + duration predictor + iSTFTNet vocoder) producing 24 kHz speech.
+
+The first CoreML port with **on-device bilingual (English + Japanese) free-text input** — no MLX, no MeCab, no IPADic, no Python G2P at runtime.
+
+<video src="https://github.com/user-attachments/assets/56eb2ffc-f915-4f8b-b6d3-1021f3d490ca" width="400"></video>
+
+## Models
+
+2 CoreML models: a flexible-length **Predictor** (BERT + LSTM duration head + text encoder) and **3 fixed-shape Decoder buckets** (128 / 256 / 512 frames). The Swift pipeline picks the smallest bucket that fits the predicted duration, pads input features with zeros, and trims the output audio.
+
+| Model | Size | Input | Output |
+|-------|------|-------|--------|
+| [Kokoro_Predictor.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/kokoro-v1/Kokoro_Predictor.mlpackage.zip) | 75 MB | input_ids [1, T≤256] (int32) + ref_s_style [1, 128] | duration [1, T] + d_for_align [1, 640, T] + t_en [1, 512, T] |
+| [Kokoro_Decoder_128.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/kokoro-v1/Kokoro_Decoder_128.mlpackage.zip) | 238 MB | en_aligned [1, 640, 128] + asr_aligned [1, 512, 128] + ref_s [1, 256] | audio [1, 76800] @ 24 kHz |
+| [Kokoro_Decoder_256.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/kokoro-v1/Kokoro_Decoder_256.mlpackage.zip) | 241 MB | en_aligned [1, 640, 256] + asr_aligned [1, 512, 256] + ref_s [1, 256] | audio [1, 153600] @ 24 kHz |
+| [Kokoro_Decoder_512.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/kokoro-v1/Kokoro_Decoder_512.mlpackage.zip) | 246 MB | en_aligned [1, 640, 512] + asr_aligned [1, 512, 512] + ref_s [1, 256] | audio [1, 307200] @ 24 kHz |
+
+## Setup
+
+1. Download the predictor and the three decoder buckets above
+2. Unzip and drag them into the Xcode project
+3. Build and run on a physical device (iOS 17+)
+
+Voices ship with the project (510×256 style tensors, ~512 KB each):
+
+- English (5): `af_heart`, `af_bella`, `am_michael`, `bf_emma`, `bm_george`
+- Japanese (5): `jf_alpha`, `jf_gongitsune`, `jm_kumo`, `jf_nezumi`, `jf_tebukuro`
+
+## On-Device G2P (no external dependencies)
+
+- **English** — lexicon-based: `us_gold` (~90k entries) + `us_silver` fallback, with possessive splitting, acronym detection, and a rule-based grapheme→phoneme fallback for OOV words. ~6 MB of bundled JSON. No MLX, no Python.
+- **Japanese** — Apple's `CFStringTokenizer` (`ja_JP` locale) emits romaji per token; `Latin-Hiragana` ICU transform converts to hiragana; a ported subset of misaki's `cutlet.HEPBURN` IPA table plus context rules (long vowels, ん assimilation, particles は→βa / へ→e) emits Kokoro-compatible phonemes. **No MeCab, no IPADic, ~zero overhead.**
+
+## Conversion Notes
+
+- **`RangeDim` for the predictor** — flexible phoneme length 1–256 (incl. BOS/EOS) so the bidirectional LSTM never sees padding tokens.
+- **Fixed-shape decoder buckets** — the iSTFTNet vocoder + InstanceNorm + bidirectional LSTM stack is length-sensitive, so we ship 3 buckets (128 / 256 / 512). Padding inside one bucket only causes a phase shift (spec corr 0.93 vs unpadded reference) which is perceptually inaudible. The smaller padding ratio you can pick, the cleaner the output — hence multiple buckets.
+- **Critical bug**: CoreML's `mod` op silently produces wrong values for `(float / scalar) % 1` (e.g. inside the SineGen of iSTFTNet). Output spec correlation drops from 0.996 to 0.67 vs PyTorch with this op in the graph. Replacing `(f0 / sr) % 1` with `(f0 / sr) - floor(f0 / sr)` brings it back to **0.996**. See [`conversion_scripts/convert_kokoro.py`](../../conversion_scripts/convert_kokoro.py) and the patched `kokoro/istftnet.py`.
+- **Bypass `pack_padded_sequence` / `pad_packed_sequence`** in the predictor's `TextEncoder` and `DurationEncoder` LSTMs — coremltools can't trace them. The LSTM runs on the unpadded tensor directly via `RangeDim`.
+- **Decoder ships at FP32** (`compute_precision=ct.precision.FLOAT32`); FP16 corrupts audio quality.
+- **Deterministic noise** — the random noise generators (`torch.randn_like` in `SineGen` and `SourceModuleHnNSF`) are zeroed before tracing so the CoreML model is bit-for-bit reproducible vs PyTorch.
+- **ANE-friendly decoder** — first vocoder inference ~700 ms, subsequent inferences ~200 ms on iPhone (warm cache).
+
+## Conversion Script
+
+[`conversion_scripts/convert_kokoro.py`](../../conversion_scripts/convert_kokoro.py)

--- a/sample_apps/MatAnyoneDemo/README.md
+++ b/sample_apps/MatAnyoneDemo/README.md
@@ -1,0 +1,62 @@
+# MatAnyoneDemo
+
+Sample iOS app for [pq-yang/MatAnyone](https://github.com/pq-yang/MatAnyone) (CVPR 2025) — temporally consistent video matting with object-level memory propagation. Given a first-frame mask the network tracks and refines an alpha matte across the whole clip, holding sharp edges (hair, semitransparent regions) much better than per-frame matting baselines. Built on the Cutie video object segmentation backbone with a dedicated mask decoder for matting.
+
+The sample app uses Vision's `VNGeneratePersonSegmentationRequest` to bootstrap the first-frame mask automatically — pick a video, tap "Remove BG", and it composites the foreground over the chosen background colour.
+
+End-to-end alpha matte parity vs the official PyTorch reference: **MAE < 2e-4, correlation 0.9999+** across 18 frames including 3 memory cycles.
+
+## Models
+
+5 mlpackages, ~111 MB total at FP16. The CoreML graph is locked to landscape **768 × 432**; portrait sources are rotated to landscape before the pipeline and rotated back afterwards.
+
+| Module | Inputs | Outputs |
+|---|---|---|
+| `encoder` | image [1, 3, 432, 768] | f16 / f8 / f4 / f2 / f1 multi-scale features + pix_feat + key + shrinkage + selection |
+| `mask_encoder` | image, pix_feat, sensory, mask | mask_value, new_sensory, obj_summary |
+| `read_first` | pix_feat, last_msk_value, sensory, last_mask, obj_memory | mem_readout (no memory attention, first-frame readout) |
+| `read` | query_key, query_selection, pix_feat, sensory, last_mask, last_pix_feat, last_msk_value, mem_key, mem_shrinkage, mem_msk_value, mem_valid, obj_memory | mem_readout (memory attention readout over a fixed-T ring buffer) |
+| `decoder` | f16 / f8 / f4 / f2 / f1, mem_readout, sensory | new_sensory, alpha matte [1, 1, 432, 768] |
+
+## Setup
+
+1. Build the mlpackages from [`conversion_scripts/convert_matanyone.py`](../../conversion_scripts/convert_matanyone.py) (release builds will be uploaded later)
+2. Drop the 5 `.mlpackage` directories into the Xcode project
+3. Build and run on a physical device (iOS 17+)
+
+## Per-Frame State Machine (Swift)
+
+The split puts all the bookkeeping in Swift so each CoreML module is a pure function of its inputs. State carried between frames:
+
+- `sensory` — `(1, 1, 256, h, w)`
+- `last_mask` — `(1, 1, H, W)`
+- `last_pix_feat` — `(1, 256, h, w)`
+- `last_msk_value` — `(1, 1, 256, h, w)`
+- `obj_memory` — `(1, 1, 1, 16, 257)` (streaming sum + count)
+- Working memory ring buffer at fixed `T_max = 5`:
+  - `mem_key` — `(1, 64, T_max·h·w)`
+  - `mem_shrinkage` — `(1, 1, T_max·h·w)`
+  - `mem_msk_value` — `(1, 256, T_max·h·w)`
+  - `mem_valid` — `(1, T_max·h·w)` per-slot validity mask
+- `current_frame`, `last_mem_frame`, `next_fifo_slot`
+
+Per-frame loop: encoder → (read_first or read) → decoder → mask_encoder → (if memory frame) update sensory + write the FIFO slot + accumulate `obj_memory`.
+
+## Conversion Notes
+
+- **Network split into 5 stateless mlpackages** so the per-frame memory state machine can live in Swift while CoreML handles the heavy compute.
+- **`single_object=False` but hard-coded `num_objects=1`** lets the chunk loops collapse to the fast path. `flip_aug=False`, `use_long_term=False`, `chunk_size=-1` match the official matting config.
+- **`torch.prod(1 - mask, dim=1)` in `aggregate` is monkey-patched to `1 - mask`** (identity for `num_objects=1`) since `prod` isn't supported by coremltools.
+- **Memory tensors are pre-flattened to rank 3** (`[1, C, T·h·w]`) to stay within Core ML's rank-5 limit.
+- **Variable-length working memory is handled by adding `(1 - valid) * -6e4`** to the similarity before top-k softmax (FP16-safe `-inf` substitute).
+- **Resolution fixed at 768 × 432** (mobile 16:9, divisible by 16). For other aspect ratios, re-run the converter with `--height/--width`.
+- **`read` and `read_first` ship CPU-only**. Their internal reshapes/slices over the singleton `num_objects` dim hit a Metal Performance Shaders assertion (`subRange.start = -1` on a length-1 dim) on iOS GPU. The encoder, mask_encoder, and decoder run fine on `.cpuAndGPU`.
+- **No warmup loop**. The official `process_video` runs the first frame 10 times with `first_frame_pred=true` to stabilise memory, but at FP16 those repeated feedback iterations drift the alpha to zero. The single seed step + one `first_frame_pred` pass already matches the Python reference within MAE < 2e-4.
+
+## First-Frame Mask Bootstrap (Vision)
+
+The Vision soft mask is binarised at 0.5 and dilated by radius 8 (separable max filter) before being handed to MatAnyone. The model can shrink the alpha but cannot recover from a mask that misses parts of the foreground, so the seed is intentionally generous.
+
+## Conversion Script
+
+[`conversion_scripts/convert_matanyone.py`](../../conversion_scripts/convert_matanyone.py)

--- a/sample_apps/SinSRDemo/README.md
+++ b/sample_apps/SinSRDemo/README.md
@@ -1,0 +1,57 @@
+# SinSRDemo
+
+Sample iOS app for [SinSR](https://github.com/wyf0912/SinSR) — single-step diffusion-based super-resolution (CVPR 2024). 4× upscaling in one denoiser pass via a Swin Transformer UNet on a VQ-VAE latent space (~113M params).
+
+<img width="512" src="sinsr_demo.png">
+
+*Left: bicubic 4× upscale, Right: SinSR single-step diffusion SR (128×128 → 512×512)*
+
+## Models
+
+| Model | Size | Input | Output |
+|-------|------|-------|--------|
+| [SinSR_Encoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/sinsr-v1/SinSR_Encoder.mlpackage.zip) | 39 MB | image [1,3,1024,1024] | latent [1,3,256,256] |
+| [SinSR_Denoiser.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/sinsr-v1/SinSR_Denoiser.mlpackage.zip) | 420 MB | input [1,6,256,256] | predicted_latent [1,3,256,256] |
+| [SinSR_Decoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/sinsr-v1/SinSR_Decoder.mlpackage.zip) | 58 MB | latent [1,3,256,256] | image [1,3,1024,1024] |
+
+## Setup
+
+1. Download the three `.mlpackage.zip` files above
+2. Unzip and drag them into the Xcode project
+3. Build and run on a physical device (iOS 17+)
+
+## Inference Pipeline
+
+```
+LQ image → resize 256² → Encoder → latent [1,3,256,256]
+                                          │
+              add noise (κ=2.0, η_T=0.99) ▼
+                                  noisy_latent
+                                          │
+               concat with LQ → [1,6,256,256]
+                                          │
+                                       Denoiser  (single step, t=14 baked in)
+                                          │
+                                  predicted_latent
+                                          │
+                       clamp [-1, 1] → Decoder → image [1,3,1024,1024]
+```
+
+The denoiser runs **once** (not iteratively) — that's the SinSR distillation. Swift handles noise injection, scaling, and latent space marshalling.
+
+## Conversion Notes
+
+- **Swin Transformer patches required for tracing**:
+  - Pre-compute relative position bias as `register_buffer`
+  - Replace `torch.roll` with `slice + concat`
+  - Rewrite attention-mask creation to avoid `__setitem__`
+  - Patch the coremltools `int` op converter to handle multi-dim tensor shape casts
+- **VQ-VAE decoder ships with vector quantization inside the CoreML model** — 8192-entry codebook with `argmin` nearest-neighbor lookup runs on-device.
+- **Denoiser input** is a 6-channel concat of `[scaled_noisy_latent, lq_image]` with the timestep baked in (always `t=14` for the single-step distillation).
+- **Denoiser must use FP32 precision**. FP16 causes a pinkish color shift via overflow inside the Swin attention layers. Encoder/Decoder are fine in FP16.
+- **Use `.cpuOnly` for the denoiser** for best accuracy. Encoder/Decoder run happily on `.cpuAndGPU` or `.all`.
+- The output has a slight, consistent color shift relative to the input — that's inherent to the SinSR distilled architecture, not a conversion artifact.
+
+## Conversion Script
+
+[`conversion_scripts/convert_sinsr.py`](../../conversion_scripts/convert_sinsr.py)

--- a/sample_apps/StableAudioDemo/README.md
+++ b/sample_apps/StableAudioDemo/README.md
@@ -1,0 +1,43 @@
+# StableAudioDemo
+
+Sample iOS app for [stabilityai/stable-audio-open-small](https://huggingface.co/stabilityai/stable-audio-open-small) — text-to-music generation (497M params). Generates up to 11.9 seconds of stereo 44.1 kHz audio from text prompts using rectified flow diffusion.
+
+<video src="https://github.com/user-attachments/assets/ea448e41-d5ae-407e-84a6-8312c1108cfd" width="400"></video>
+
+## Models
+
+4 CoreML models: T5 text encoder, NumberEmbedder (seconds conditioning), DiT (diffusion transformer), and VAE decoder (Oobleck).
+
+| Model | Size | Input | Output |
+|-------|------|-------|--------|
+| [StableAudioT5Encoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/stable-audio-v1/StableAudioT5Encoder.mlpackage.zip) | 105 MB | input_ids [1, 64] | text_embeddings [1, 64, 768] |
+| [StableAudioNumberEmbedder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/stable-audio-v1/StableAudioNumberEmbedder.mlpackage.zip) | 396 KB | normalized_seconds [1] | seconds_embedding [1, 768] |
+| [StableAudioDiT.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/stable-audio-v1/StableAudioDiT.mlpackage.zip) | 326 MB (INT8) | latent [1,64,256] + timestep + conditioning | velocity [1,64,256] |
+| [StableAudioDiT_FP32.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/stable-audio-v1/StableAudioDiT_FP32.mlpackage.zip) | 1.3 GB (FP32) | latent [1,64,256] + timestep + conditioning | velocity [1,64,256] |
+| [StableAudioVAEDecoder.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/stable-audio-v1/StableAudioVAEDecoder.mlpackage.zip) | 149 MB | latent [1, 64, 256] | stereo audio [1, 2, 524288] @ 44.1 kHz |
+
+## Setup
+
+1. Download the four `.mlpackage.zip` files (pick **either** `StableAudioDiT` **or** `StableAudioDiT_FP32`)
+2. Unzip and drag them into the Xcode project
+3. Build and run on a physical device (iOS 17+)
+
+## DiT Variant Selection
+
+| Variant | Compute units | Quality | Speed | Memory |
+|---------|---------------|---------|-------|--------|
+| `StableAudioDiT` (INT8) | `.cpuAndGPU` | Slight quantization loss | Fastest | 326 MB |
+| `StableAudioDiT_FP32` | `.cpuOnly` | Best | Slower | 1.3 GB |
+
+FP16 weights overflow inside the DiT attention on iOS GPU, so the high-quality path requires FP32 compute on CPU. The INT8 GPU path is the practical default for most devices.
+
+## Conversion Notes
+
+- **DiT INT8 + `.cpuAndGPU`** — fastest path, slight quality loss from quantization. Runs cleanly on the GPU because INT8 dequantizes to FP16/FP32 element-wise without the overflow issue.
+- **DiT FP32 + `.cpuOnly`** — best quality, larger and slower. Required because the FP16 attention path overflows on the iOS GPU. CPU FP32 is the fallback that gives correct results.
+- **T5 INT8 may emit occasional NaN values** — the sample app sanitizes the embeddings (replaces NaN with 0) before passing them to the DiT.
+- **VAE Decoder FP16** — `weight_norm` must be removed before tracing because of the Snake activation; see the `remove_weight_norm()` call in the conversion script.
+
+## Conversion Script
+
+[`conversion_scripts/convert_stable_audio.py`](../../conversion_scripts/convert_stable_audio.py)


### PR DESCRIPTION
## Summary

- Move the inline `**Conversion notes:**` / `**Implementation notes:**` blocks for **MatAnyone, SinSR, Hyper-SD, Kokoro-82M, Stable Audio Open Small, Basic Pitch** out of the top-level `README.md` and into per-app `sample_apps/<Model>Demo/README.md` files.
- Each new app README follows the existing `YOLO26Demo` / `YOLOWorldDemo` / `YOLOv9Demo` pattern: brief overview, model table, setup, model-specific conversion notes.
- The top-level README now keeps the catalog clean — each affected model has a single "See `sample_apps/.../README.md` for details" line right under its table.
- Cross-cutting lessons that came up across multiple models are appended to `docs/coreml_conversion_notes.md` so they're discoverable from one place.

## Files

New app READMEs:
- `sample_apps/MatAnyoneDemo/README.md`
- `sample_apps/SinSRDemo/README.md`
- `sample_apps/HyperSDDemo/README.md`
- `sample_apps/KokoroDemo/README.md`
- `sample_apps/StableAudioDemo/README.md`
- `sample_apps/BasicPitchDemo/README.md`

`docs/coreml_conversion_notes.md` additions:
- Extended the *Unsupported Operations* table with `torch.prod`, `pack_padded_sequence` / `pad_packed_sequence`, `mod` on float / scalar, `torch.randn_like`, `torch.roll`, in-place attention-mask construction, and `nn.utils.weight_norm`.
- New sections: *Tensor Rank Limits*, *FP16 Attention Overflow*, *FP16-Safe Masked Softmax*, *FP16 Feedback Loops Drift*, *Swin Transformer Conversion Checklist*, *Apple `ml-stable-diffusion` Gotchas*, *NaN Sanitisation Around INT8 Models*, *MPS Slice on Singleton Dimension Crashes*.

## Test plan

- [x] `grep "Conversion notes\|Implementation notes" README.md` returns nothing
- [x] All per-app READMEs render on GitHub
- [x] No mlpackage / xcuserdata / unrelated changes in the commit