### PR TITLE
Add MoGe-2 monocular geometry estimation (CVPR 2025)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 __pycache__/
 *.xcuserstate
 .DS_Store
+
+# Vendored upstream repos (clone from README link, do not commit)
+conversion_scripts/MoGe/

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You are free to do or not.
   - [Lama](#lama)
 
 - [**Monocular Depth Estimation**](#monocular-depth-estimation)
+  - [MoGe-2](#moge-2)
   - [MiDaS](#midas)
   
 - [**Stable Diffusion**](#stable-diffusion) **:text2image**
@@ -873,6 +874,14 @@ White-box facial image cartoonizaiton
 |[Lama](https://drive.google.com/drive/folders/1s_uICJQykFFxgVubpBNeLLDL0JsxgdCd?usp=sharing)|216.6MB| Image (Color 800 × 800), Image (GrayScale 800 × 800)| Image (Color 800 × 800) |[advimman/lama](https://github.com/advimman/lama)|[Apache2.0](https://github.com/advimman/lama/blob/main/LICENSE)|To use see sample.| [john-rocky/lama-cleaner-iOS](https://github.com/john-rocky/lama-cleaner-iOS) | [mallman/CoreMLaMa](https://github.com/mallman/CoreMLaMa)|
 
 # Monocular Depth Estimation
+
+### MoGe-2
+
+[microsoft/MoGe](https://github.com/microsoft/MoGe) (CVPR 2025 Oral) — open-domain monocular 3D geometry from a single image. Predicts a metric depth map, surface normals, and a confidence mask in one forward pass on a DINOv2 ViT-B backbone with three task heads. The successor to MiDaS-style relative depth: depth comes out in real meters.
+
+| Module | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| MoGe-2 ViT-B + normal | ~200 MB FP16 | Image (RGB 504 × 504) | depth + normal + mask + metric_scale | [microsoft/MoGe](https://github.com/microsoft/MoGe) | [MIT](https://github.com/microsoft/MoGe/blob/main/LICENSE) | 2025 | [MoGe2Demo](sample_apps/MoGe2Demo/) | [convert_moge2.py](conversion_scripts/convert_moge2.py) |
 
 ### [MiDaS](https://drive.google.com/file/d/1agGnt5Cq5CGzoNDl9Nb-3u7pB5SrIbN4/view?usp=share_link)
 Towards Robust Monocular Depth Estimation: Mixing Datasets for Zero-shot Cross-dataset Transfer

--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ White-box facial image cartoonizaiton
 
 | Module | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| MoGe-2 ViT-B + normal | ~200 MB FP16 | Image (RGB 504 × 504) | depth + normal + mask + metric_scale | [microsoft/MoGe](https://github.com/microsoft/MoGe) | [MIT](https://github.com/microsoft/MoGe/blob/main/LICENSE) | 2025 | [MoGe2Demo](sample_apps/MoGe2Demo/) | [convert_moge2.py](conversion_scripts/convert_moge2.py) |
+| [MoGe-2 ViT-B + normal](https://github.com/john-rocky/CoreML-Models/releases/download/moge2-v1/MoGe2_ViTB_Normal_504.mlpackage.zip) | ~200 MB FP16 | Image (RGB 504 × 504) | depth + normal + mask + metric_scale | [microsoft/MoGe](https://github.com/microsoft/MoGe) | [MIT](https://github.com/microsoft/MoGe/blob/main/LICENSE) | 2025 | [MoGe2Demo](sample_apps/MoGe2Demo/) | [convert_moge2.py](conversion_scripts/convert_moge2.py) |
 
 ### [MiDaS](https://drive.google.com/file/d/1agGnt5Cq5CGzoNDl9Nb-3u7pB5SrIbN4/view?usp=share_link)
 Towards Robust Monocular Depth Estimation: Mixing Datasets for Zero-shot Cross-dataset Transfer

--- a/conversion_scripts/convert_moge2.py
+++ b/conversion_scripts/convert_moge2.py
@@ -1,0 +1,277 @@
+"""
+Convert MoGe-2 (Microsoft, CVPR'25) to Core ML.
+
+Default variant: `Ruicheng/moge-2-vitb-normal` (104M, DINOv2 ViT-B/14 + normal +
+metric scale heads). Resolution is locked to a fixed square so the
+aspect-ratio-aware num_tokens path collapses to constants.
+
+The wrapper:
+  - Takes a (1, 3, H, W) image in [0, 1] range. ImageNet normalization is
+    already inside DINOv2Encoder, so we feed [0, 1] directly.
+  - Pre-computes the bicubic-interpolated DINOv2 positional embedding for the
+    fixed token grid and replaces `interpolate_pos_encoding` with a constant
+    lookup, so the traced graph never hits bicubic + antialias.
+  - Hard-codes base_h = base_w = H // 14 (= 36 at 504x504).
+  - Returns a flat tuple: (points, depth, normal, mask, metric_scale).
+    `points` is (1, H, W, 3); `depth` is points[..., 2] cloned out so the
+    Swift side does not have to slice a 4-D tensor.
+
+Recovery of focal / shift / camera intrinsics is left to the Swift driver.
+
+Usage:
+  python convert_moge2.py                              # ViT-B normal, 504x504
+  python convert_moge2.py --variant vits-normal --size 392
+  python convert_moge2.py --output MoGe2_ViTB_504.mlpackage
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import coremltools as ct
+from coremltools.converters.mil.frontend.torch import ops as _ct_ops
+from coremltools.converters.mil import Builder as mb
+
+REPO = Path(__file__).resolve().parent / "MoGe"
+sys.path.insert(0, str(REPO))
+
+from moge.model.v2 import MoGeModel  # noqa: E402
+from moge.utils.geometry_torch import normalized_view_plane_uv  # noqa: E402
+
+
+# ============================================================
+# coremltools 9.0 patch: `int` op for multi-dim shape casts.
+# DINOv2 emits int casts on a 2-element shape tensor (h, w) when
+# building positional indices; the stock converter assumes scalars.
+# Same patch as conversion_scripts/convert_sinsr.py.
+# ============================================================
+
+def _patched_int(context, node):
+    inputs = _ct_ops._get_inputs(context, node)
+    x = inputs[0]
+    if x.val is not None:
+        val = x.val
+        if isinstance(val, np.ndarray):
+            val = int(val.item()) if val.ndim == 0 else int(val.flat[0])
+        else:
+            val = int(val)
+        res = mb.const(val=np.int32(val), name=node.name)
+    else:
+        res = mb.cast(x=x, dtype="int32", name=node.name)
+    context.add(res)
+
+
+_ct_ops._TORCH_OPS_REGISTRY.register_func(_patched_int, torch_alias=["int"], override=True)
+
+
+# ============================================================
+# Pre-compute and freeze DINOv2 positional embedding
+# ============================================================
+
+def freeze_pos_embed(model: MoGeModel, base_h: int, base_w: int) -> None:
+    """Replace `interpolate_pos_encoding` with a constant lookup.
+
+    DINOv2's stock implementation does a bicubic + antialias resize of the
+    pretrained pos_embed every forward call. coremltools cannot trace bicubic
+    + antialias cleanly, but the result depends only on the (h, w) we already
+    fixed at conversion time, so we just bake it once and return it.
+    """
+    backbone = model.encoder.backbone
+    img_h, img_w = base_h * backbone.patch_size, base_w * backbone.patch_size
+    # Build a dummy input that has the correct (h, w); only the *shape* matters
+    # because interpolate_pos_encoding only reads x.shape[1] and the (h, w)
+    # arguments.
+    dummy = torch.zeros(1, 3, img_h, img_w)
+    tokens = backbone.patch_embed(dummy)
+    # Mimic the cls-token concat that happens in prepare_tokens_with_masks so
+    # interpolate_pos_encoding sees the correct npatch.
+    cls = backbone.cls_token.expand(tokens.shape[0], -1, -1)
+    x = torch.cat([cls, tokens], dim=1)
+    with torch.no_grad():
+        pos = backbone.interpolate_pos_encoding(x, img_h, img_w)
+    backbone.register_buffer("_frozen_pos_embed", pos.detach().clone(), persistent=False)
+
+    def _frozen_interp(self, x, h, w):  # noqa: ARG001
+        return self._frozen_pos_embed
+
+    backbone.interpolate_pos_encoding = _frozen_interp.__get__(backbone, type(backbone))
+
+
+# ============================================================
+# Wrapper
+# ============================================================
+
+class MoGe2Wrapper(nn.Module):
+    """Stateless wrapper exposing MoGe-2 as a single CoreML model.
+
+    Mirrors MoGeModel.forward but with a fixed square resolution, hard-coded
+    `base_h`/`base_w`, no dict outputs and no Python conditionals.
+    """
+
+    def __init__(self, model: MoGeModel, size: int):
+        super().__init__()
+        assert size % 14 == 0, f"size must be a multiple of 14 (DINOv2 patch); got {size}"
+        self.model = model
+        self.size = size
+        self.base = size // 14  # 504 -> 36
+
+        # Pre-compute UV grids for all 5 pyramid levels (depend only on shape).
+        for level in range(5):
+            uv = normalized_view_plane_uv(
+                width=self.base * 2 ** level,
+                height=self.base * 2 ** level,
+                aspect_ratio=1.0,
+                dtype=torch.float32,
+            )
+            uv = uv.permute(2, 0, 1).unsqueeze(0).contiguous()  # (1, 2, h, w)
+            self.register_buffer(f"uv_{level}", uv, persistent=False)
+
+    def forward(self, image: torch.Tensor):
+        # Encoder. Outputs (B, dim_out, base, base) feature map plus cls token.
+        features_l0, cls_token = self.model.encoder(
+            image, self.base, self.base, return_class_token=True
+        )
+
+        # Build the 5-level feature pyramid: only level 0 has encoder output;
+        # levels 1..4 are pure UV until the neck mixes them in.
+        levels = [features_l0, None, None, None, None]
+        for level in range(5):
+            uv = getattr(self, f"uv_{level}").expand(image.shape[0], -1, -1, -1)
+            if levels[level] is None:
+                levels[level] = uv
+            else:
+                levels[level] = torch.cat([levels[level], uv], dim=1)
+
+        features = self.model.neck(levels)
+
+        points = self.model.points_head(features)[-1]
+        normal = self.model.normal_head(features)[-1]
+        mask = self.model.mask_head(features)[-1]
+        metric_scale = self.model.scale_head(cls_token)
+
+        # Resize back to input resolution.
+        points = F.interpolate(points, (self.size, self.size), mode="bilinear", align_corners=False)
+        normal = F.interpolate(normal, (self.size, self.size), mode="bilinear", align_corners=False)
+        mask = F.interpolate(mask, (self.size, self.size), mode="bilinear", align_corners=False)
+
+        # Match MoGeModel.forward postprocessing for remap='exp'.
+        points = points.permute(0, 2, 3, 1)  # (B, H, W, 3)
+        xy, z = points.split([2, 1], dim=-1)
+        z = torch.exp(z)
+        points = torch.cat([xy * z, z], dim=-1)
+
+        # Pull depth out before downstream so Swift does not have to slice
+        # a 4-D tensor on its own.
+        depth = points[..., 2]  # (B, H, W)
+
+        normal = normal.permute(0, 2, 3, 1)  # (B, H, W, 3)
+        normal = F.normalize(normal, dim=-1)
+
+        mask = mask.squeeze(1).sigmoid()  # (B, H, W)
+        metric_scale = metric_scale.squeeze(1).exp()  # (B,)
+
+        return points, depth, normal, mask, metric_scale
+
+
+# ============================================================
+# Main
+# ============================================================
+
+VARIANTS = {
+    "vits-normal": "Ruicheng/moge-2-vits-normal",
+    "vitb-normal": "Ruicheng/moge-2-vitb-normal",
+    "vitl-normal": "Ruicheng/moge-2-vitl-normal",
+    "vitl": "Ruicheng/moge-2-vitl",
+}
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--variant", default="vitb-normal", choices=list(VARIANTS.keys()))
+    p.add_argument("--size", type=int, default=504, help="square input size (must be multiple of 14)")
+    p.add_argument("--output", type=str, default=None)
+    p.add_argument("--quantize", action="store_true", help="apply linear FP16 -> INT8 weight quant")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    repo_id = VARIANTS[args.variant]
+    print(f"[1/5] Loading MoGe-2 from {repo_id}")
+    model = MoGeModel.from_pretrained(repo_id)
+    model.eval()
+    # Use PyTorch native SDPA so the conversion sees an op coremltools knows.
+    model.enable_pytorch_native_sdpa()
+    # Disable the bicubic+antialias fast path inside DINOv2.
+    model.onnx_compatible_mode = True
+
+    base = args.size // 14
+    print(f"[2/5] Freezing pos_embed for {args.size}x{args.size} ({base}x{base} tokens)")
+    freeze_pos_embed(model, base, base)
+
+    print("[3/5] Building wrapper and tracing")
+    wrapper = MoGe2Wrapper(model, args.size).eval()
+    example = torch.rand(1, 3, args.size, args.size)
+    with torch.no_grad():
+        ref_points, ref_depth, ref_normal, ref_mask, ref_scale = wrapper(example)
+        traced = torch.jit.trace(wrapper, example, strict=False)
+        # Sanity check the traced module against eager mode.
+        t_points, t_depth, t_normal, t_mask, t_scale = traced(example)
+        for name, ref, got in [
+            ("points", ref_points, t_points),
+            ("depth", ref_depth, t_depth),
+            ("normal", ref_normal, t_normal),
+            ("mask", ref_mask, t_mask),
+            ("scale", ref_scale, t_scale),
+        ]:
+            err = (ref - got).abs().max().item()
+            print(f"        trace parity {name:8s}: max abs err = {err:.3e}")
+            assert err < 1e-4, f"trace parity broke for {name}"
+
+    print("[4/5] Converting to Core ML")
+    mlmodel = ct.convert(
+        traced,
+        inputs=[
+            ct.ImageType(
+                name="image",
+                shape=(1, 3, args.size, args.size),
+                scale=1.0 / 255.0,
+                color_layout=ct.colorlayout.RGB,
+            )
+        ],
+        outputs=[
+            ct.TensorType(name="points"),
+            ct.TensorType(name="depth"),
+            ct.TensorType(name="normal"),
+            ct.TensorType(name="mask"),
+            ct.TensorType(name="metric_scale"),
+        ],
+        compute_precision=ct.precision.FLOAT16,
+        minimum_deployment_target=ct.target.iOS17,
+        convert_to="mlprogram",
+    )
+
+    if args.quantize:
+        print("        applying INT8 weight quantization")
+        from coremltools.optimize.coreml import (
+            OpLinearQuantizerConfig,
+            OptimizationConfig,
+            linear_quantize_weights,
+        )
+        cfg = OptimizationConfig(
+            global_config=OpLinearQuantizerConfig(mode="linear_symmetric", dtype="int8")
+        )
+        mlmodel = linear_quantize_weights(mlmodel, cfg)
+
+    out_path = args.output or f"MoGe2_{args.variant.replace('-', '_')}_{args.size}.mlpackage"
+    print(f"[5/5] Saving to {out_path}")
+    mlmodel.save(out_path)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/coreml_conversion_notes.md
+++ b/docs/coreml_conversion_notes.md
@@ -405,6 +405,38 @@ It's not a fix for the underlying issue (FP32 conversion of the same encoder is 
 
 ---
 
+## DINOv2 Backbone Conversion Checklist
+
+DINOv2 ViT-S/B/L backbones (MoGe-2, etc.) are otherwise straightforward to convert, but the official implementation has two pieces of dynamic logic that you have to neutralise before tracing.
+
+1. **Freeze the interpolated positional embedding.** `interpolate_pos_encoding` does a **bicubic + antialias** resize of the pretrained pos_embed every forward call. coremltools cannot trace bicubic + antialias cleanly. Since the result depends only on the input (h, w), and you are converting at a fixed resolution anyway, pre-compute the interpolated pos_embed once at conversion time and replace the method with a constant lookup:
+
+   ```python
+   def freeze_pos_embed(model, base_h, base_w):
+       backbone = model.encoder.backbone
+       img_h, img_w = base_h * backbone.patch_size, base_w * backbone.patch_size
+       dummy = torch.zeros(1, 3, img_h, img_w)
+       tokens = backbone.patch_embed(dummy)
+       cls = backbone.cls_token.expand(1, -1, -1)
+       x = torch.cat([cls, tokens], dim=1)
+       with torch.no_grad():
+           pos = backbone.interpolate_pos_encoding(x, img_h, img_w)
+       backbone.register_buffer("_frozen_pos_embed", pos.detach().clone(), persistent=False)
+       def _frozen_interp(self, x, h, w):
+           return self._frozen_pos_embed
+       backbone.interpolate_pos_encoding = _frozen_interp.__get__(backbone, type(backbone))
+   ```
+
+2. **Set `onnx_compatible_mode = True`** on the encoder. This disables the antialias path inside the rest of the encoder forward (not just `interpolate_pos_encoding`) so the only `F.interpolate` calls left are bilinear with explicit `size`.
+
+3. **Apply the same `int` op patch as Swin / SinSR.** DINOv2's positional indexing emits int casts on a 2-element shape tensor that the stock coremltools converter assumes are scalars.
+
+4. **Call `model.enable_pytorch_native_sdpa()`** so attention lowers to `F.scaled_dot_product_attention`, which coremltools handles natively. The custom `MemEffAttention` path otherwise emits an op pattern coremltools cannot fold cleanly.
+
+A reference implementation is in [`conversion_scripts/convert_moge2.py`](../conversion_scripts/convert_moge2.py).
+
+---
+
 ## MPS Slice on Singleton Dimension Crashes
 
 **Some Core ML graphs crash on iOS GPU with:**

--- a/sample_apps/MoGe2Demo/MoGe2Demo.xcodeproj/project.pbxproj
+++ b/sample_apps/MoGe2Demo/MoGe2Demo.xcodeproj/project.pbxproj
@@ -1,0 +1,68 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E10000010000000000000001 /* MoGe2DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000001 /* MoGe2DemoApp.swift */; };
+		E10000010000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000002 /* ContentView.swift */; };
+		E10000010000000000000003 /* DepthEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000003 /* DepthEstimator.swift */; };
+		E10000010000000000000004 /* Visualization.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000004 /* Visualization.swift */; };
+		E10000010000000000000005 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000005 /* Assets.xcassets */; };
+		E10000010000000000000007 /* MoGe2_ViTB_Normal_504.mlpackage in Sources */ = {isa = PBXBuildFile; fileRef = E10000020000000000000007 /* MoGe2_ViTB_Normal_504.mlpackage */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		E10000020000000000000001 /* MoGe2DemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoGe2DemoApp.swift; sourceTree = "<group>"; };
+		E10000020000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		E10000020000000000000003 /* DepthEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepthEstimator.swift; sourceTree = "<group>"; };
+		E10000020000000000000004 /* Visualization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visualization.swift; sourceTree = "<group>"; };
+		E10000020000000000000005 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E10000020000000000000006 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E10000020000000000000007 /* MoGe2_ViTB_Normal_504.mlpackage */ = {isa = PBXFileReference; lastKnownFileType = folder.mlpackage; path = MoGe2_ViTB_Normal_504.mlpackage; sourceTree = "<group>"; };
+		E10000020000000000000010 /* MoGe2Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MoGe2Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E10000030000000000000001 /* Frameworks */ = { isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E10000040000000000000001 = { isa = PBXGroup; children = (E10000040000000000000002, E10000040000000000000003); sourceTree = "<group>"; };
+		E10000040000000000000002 /* MoGe2Demo */ = { isa = PBXGroup; children = (E10000020000000000000001, E10000020000000000000002, E10000020000000000000003, E10000020000000000000004, E10000020000000000000007, E10000020000000000000005, E10000020000000000000006); path = MoGe2Demo; sourceTree = "<group>"; };
+		E10000040000000000000003 /* Products */ = { isa = PBXGroup; children = (E10000020000000000000010); name = Products; sourceTree = "<group>"; };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E10000050000000000000001 /* MoGe2Demo */ = { isa = PBXNativeTarget; buildConfigurationList = E10000070000000000000001; buildPhases = (E10000060000000000000001, E10000030000000000000001, E10000060000000000000002); buildRules = (); dependencies = (); name = MoGe2Demo; productName = MoGe2Demo; productReference = E10000020000000000000010; productType = "com.apple.product-type.application"; };
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E10000080000000000000001 /* Project object */ = { isa = PBXProject; attributes = { BuildIndependentTargetsInParallel = 1; LastSwiftUpdateCheck = 1500; LastUpgradeCheck = 1500; TargetAttributes = { E10000050000000000000001 = { CreatedOnToolsVersion = 15.0; }; }; }; buildConfigurationList = E10000070000000000000003; compatibilityVersion = "Xcode 14.0"; developmentRegion = en; hasScannedForEncodings = 0; knownRegions = (en, Base); mainGroup = E10000040000000000000001; productRefGroup = E10000040000000000000003; projectDirPath = ""; projectRoot = ""; targets = (E10000050000000000000001); };
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E10000060000000000000002 /* Resources */ = { isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (E10000010000000000000005); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E10000060000000000000001 /* Sources */ = { isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (E10000010000000000000007, E10000010000000000000001, E10000010000000000000002, E10000010000000000000003, E10000010000000000000004); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		E10000090000000000000001 /* Debug */ = { isa = XCBuildConfiguration; buildSettings = { ALWAYS_SEARCH_USER_PATHS = NO; ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES; CLANG_ANALYZER_NONNULL = YES; CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE; CLANG_CXX_LANGUAGE_STANDARD = "gnu++20"; CLANG_ENABLE_MODULES = YES; CLANG_ENABLE_OBJC_ARC = YES; CLANG_ENABLE_OBJC_WEAK = YES; CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES; CLANG_WARN_BOOL_CONVERSION = YES; CLANG_WARN_COMMA = YES; CLANG_WARN_CONSTANT_CONVERSION = YES; CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES; CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR; CLANG_WARN_DOCUMENTATION_COMMENTS = YES; CLANG_WARN_EMPTY_BODY = YES; CLANG_WARN_ENUM_CONVERSION = YES; CLANG_WARN_INFINITE_RECURSION = YES; CLANG_WARN_INT_CONVERSION = YES; CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES; CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES; CLANG_WARN_OBJC_LITERAL_CONVERSION = YES; CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR; CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES; CLANG_WARN_RANGE_LOOP_ANALYSIS = YES; CLANG_WARN_STRICT_PROTOTYPES = YES; CLANG_WARN_SUSPICIOUS_MOVE = YES; CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE; CLANG_WARN_UNREACHABLE_CODE = YES; CLANG_WARN__DUPLICATE_METHOD_MATCH = YES; COPY_PHASE_STRIP = NO; DEBUG_INFORMATION_FORMAT = dwarf; ENABLE_STRICT_OBJC_MSGSEND = YES; ENABLE_TESTABILITY = YES; ENABLE_USER_SCRIPT_SANDBOXING = YES; GCC_C_LANGUAGE_STANDARD = gnu17; GCC_DYNAMIC_NO_PIC = NO; GCC_NO_COMMON_BLOCKS = YES; GCC_OPTIMIZATION_LEVEL = 0; GCC_PREPROCESSOR_DEFINITIONS = ("DEBUG=1", "$(inherited)"); GCC_WARN_64_TO_32_BIT_CONVERSION = YES; GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR; GCC_WARN_UNDECLARED_SELECTOR = YES; GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE; GCC_WARN_UNUSED_FUNCTION = YES; GCC_WARN_UNUSED_VARIABLE = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE; MTL_FAST_MATH = YES; ONLY_ACTIVE_ARCH = YES; SDKROOT = iphoneos; SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)"; SWIFT_OPTIMIZATION_LEVEL = "-Onone"; }; name = Debug; };
+		E10000090000000000000002 /* Release */ = { isa = XCBuildConfiguration; buildSettings = { ALWAYS_SEARCH_USER_PATHS = NO; ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES; CLANG_ANALYZER_NONNULL = YES; CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE; CLANG_CXX_LANGUAGE_STANDARD = "gnu++20"; CLANG_ENABLE_MODULES = YES; CLANG_ENABLE_OBJC_ARC = YES; CLANG_ENABLE_OBJC_WEAK = YES; CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES; CLANG_WARN_BOOL_CONVERSION = YES; CLANG_WARN_COMMA = YES; CLANG_WARN_CONSTANT_CONVERSION = YES; CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES; CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR; CLANG_WARN_DOCUMENTATION_COMMENTS = YES; CLANG_WARN_EMPTY_BODY = YES; CLANG_WARN_ENUM_CONVERSION = YES; CLANG_WARN_INFINITE_RECURSION = YES; CLANG_WARN_INT_CONVERSION = YES; CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES; CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES; CLANG_WARN_OBJC_LITERAL_CONVERSION = YES; CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR; CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES; CLANG_WARN_RANGE_LOOP_ANALYSIS = YES; CLANG_WARN_STRICT_PROTOTYPES = YES; CLANG_WARN_SUSPICIOUS_MOVE = YES; CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE; CLANG_WARN_UNREACHABLE_CODE = YES; CLANG_WARN__DUPLICATE_METHOD_MATCH = YES; COPY_PHASE_STRIP = NO; DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"; ENABLE_NS_ASSERTIONS = NO; ENABLE_STRICT_OBJC_MSGSEND = YES; ENABLE_USER_SCRIPT_SANDBOXING = YES; GCC_C_LANGUAGE_STANDARD = gnu17; GCC_NO_COMMON_BLOCKS = YES; GCC_WARN_64_TO_32_BIT_CONVERSION = YES; GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR; GCC_WARN_UNDECLARED_SELECTOR = YES; GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE; GCC_WARN_UNUSED_FUNCTION = YES; GCC_WARN_UNUSED_VARIABLE = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; MTL_ENABLE_DEBUG_INFO = NO; MTL_FAST_MATH = YES; SDKROOT = iphoneos; SWIFT_COMPILATION_MODE = wholemodule; VALIDATE_PRODUCT = YES; }; name = Release; };
+		E10000090000000000000003 /* Debug */ = { isa = XCBuildConfiguration; buildSettings = { ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon; ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor; CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; DEVELOPMENT_TEAM = MFN25KNUGJ; ENABLE_PREVIEWS = YES; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_FILE = MoGe2Demo/Info.plist; INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES; INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES; INFOPLIST_KEY_UILaunchScreen_Generation = YES; INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"; INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait"; LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks"); MARKETING_VERSION = 1.0; PRODUCT_BUNDLE_IDENTIFIER = "com.coreml-models.moge2demo"; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_EMIT_LOC_STRINGS = YES; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = "1,2"; }; name = Debug; };
+		E10000090000000000000004 /* Release */ = { isa = XCBuildConfiguration; buildSettings = { ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon; ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor; CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; DEVELOPMENT_TEAM = MFN25KNUGJ; ENABLE_PREVIEWS = YES; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_FILE = MoGe2Demo/Info.plist; INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES; INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES; INFOPLIST_KEY_UILaunchScreen_Generation = YES; INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"; INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait"; LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks"); MARKETING_VERSION = 1.0; PRODUCT_BUNDLE_IDENTIFIER = "com.coreml-models.moge2demo"; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_EMIT_LOC_STRINGS = YES; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = "1,2"; }; name = Release; };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E10000070000000000000001 = { isa = XCConfigurationList; buildConfigurations = (E10000090000000000000003, E10000090000000000000004); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		E10000070000000000000003 = { isa = XCConfigurationList; buildConfigurations = (E10000090000000000000001, E10000090000000000000002); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+/* End XCConfigurationList section */
+	};
+	rootObject = E10000080000000000000001 /* Project object */;
+}

--- a/sample_apps/MoGe2Demo/MoGe2Demo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/MoGe2Demo/MoGe2Demo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/MoGe2Demo/MoGe2Demo/Assets.xcassets/Contents.json
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/sample_apps/MoGe2Demo/MoGe2Demo/ContentView.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/ContentView.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+import PhotosUI
+
+struct ContentView: View {
+    @StateObject private var estimator = DepthEstimator()
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var originalImage: UIImage?
+    @State private var depthImage: UIImage?
+    @State private var normalImage: UIImage?
+    @State private var depthMin: Float = 0
+    @State private var depthMax: Float = 0
+    @State private var processingTime: Double?
+    @State private var isProcessing = false
+    @State private var status = ""
+    @State private var view: ViewMode = .depth
+
+    enum ViewMode: String, CaseIterable, Identifiable {
+        case original, depth, normal
+        var id: String { rawValue }
+        var label: String { rawValue.capitalized }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Status bar
+                HStack {
+                    Circle().fill(estimator.isReady ? .green : .red).frame(width: 8, height: 8)
+                    Text(estimator.isReady ? "Ready" : "Loading model...")
+                        .font(.caption).foregroundColor(.secondary)
+                    Spacer()
+                    if let t = processingTime {
+                        Text(String(format: "%.2fs", t))
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 4)
+
+                // Image display
+                GeometryReader { _ in
+                    Group {
+                        if depthImage != nil {
+                            displayedImage
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        } else if let original = originalImage {
+                            Image(uiImage: original)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        } else {
+                            VStack(spacing: 12) {
+                                Image(systemName: "cube.transparent")
+                                    .font(.system(size: 60))
+                                    .foregroundColor(.secondary)
+                                Text("Select a photo to estimate depth + surface normals")
+                                    .multilineTextAlignment(.center)
+                                    .foregroundColor(.secondary)
+                                    .padding(.horizontal, 24)
+                            }
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
+                    }
+                }
+
+                // Mode picker + metric depth readout
+                if depthImage != nil {
+                    Picker("View", selection: $view) {
+                        ForEach(ViewMode.allCases) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal)
+
+                    if depthMax > 0 {
+                        Text(String(format: "Depth range: %.2f m – %.2f m", depthMin, depthMax))
+                            .font(.caption.monospacedDigit())
+                            .foregroundColor(.secondary)
+                            .padding(.top, 4)
+                    }
+                }
+
+                // Controls
+                VStack(spacing: 12) {
+                    if isProcessing {
+                        ProgressView(status)
+                    }
+
+                    HStack(spacing: 16) {
+                        PhotosPicker(selection: $selectedItem, matching: .images) {
+                            Label("Select Photo", systemImage: "photo.badge.plus")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+
+                        if let original = originalImage {
+                            Button {
+                                run(original)
+                            } label: {
+                                Label("Estimate", systemImage: "cube.fill")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.blue)
+                            .disabled(isProcessing || !estimator.isReady)
+                        }
+                    }
+
+                    if let depth = depthImage, view == .depth {
+                        ShareLink(item: Image(uiImage: depth),
+                                  preview: SharePreview("Depth", image: Image(uiImage: depth))) {
+                            Label("Share Depth Map", systemImage: "square.and.arrow.up")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("MoGe-2")
+            .onChange(of: selectedItem) { _ in loadImage() }
+        }
+    }
+
+    private var displayedImage: Image {
+        switch view {
+        case .original:
+            return Image(uiImage: originalImage ?? UIImage())
+        case .depth:
+            return Image(uiImage: depthImage ?? UIImage())
+        case .normal:
+            return Image(uiImage: normalImage ?? UIImage())
+        }
+    }
+
+    private func loadImage() {
+        guard let item = selectedItem else { return }
+        depthImage = nil
+        normalImage = nil
+        processingTime = nil
+        depthMin = 0
+        depthMax = 0
+        status = ""
+        Task {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let img = UIImage(data: data) {
+                originalImage = img
+            }
+        }
+    }
+
+    private func run(_ image: UIImage) {
+        isProcessing = true
+        status = "Estimating depth..."
+        depthImage = nil
+        normalImage = nil
+        processingTime = nil
+        Task {
+            let start = CFAbsoluteTimeGetCurrent()
+            do {
+                let result = try await estimator.estimate(image: image)
+                let elapsed = CFAbsoluteTimeGetCurrent() - start
+                let depthImg = Visualization.depthImage(
+                    result.depth, size: result.size, dMin: result.depthMin, dMax: result.depthMax,
+                    validX: result.validX, validY: result.validY, validW: result.validW, validH: result.validH
+                )
+                let normalImg = Visualization.normalImage(
+                    result.normal, mask: result.mask, size: result.size,
+                    validX: result.validX, validY: result.validY, validW: result.validW, validH: result.validH
+                )
+                await MainActor.run {
+                    depthImage = depthImg
+                    normalImage = normalImg
+                    depthMin = result.depthMin
+                    depthMax = result.depthMax
+                    processingTime = elapsed
+                    isProcessing = false
+                    status = ""
+                    view = .depth
+                }
+            } catch {
+                await MainActor.run {
+                    status = "Error: \(error.localizedDescription)"
+                    isProcessing = false
+                }
+            }
+        }
+    }
+}

--- a/sample_apps/MoGe2Demo/MoGe2Demo/DepthEstimator.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/DepthEstimator.swift
@@ -1,0 +1,309 @@
+import CoreML
+import UIKit
+import Accelerate
+
+/// MoGe-2 ViT-B (504x504, FP16) wrapped in a small Swift driver.
+///
+/// The CoreML model takes a single ImageType input (`image`) and returns five
+/// outputs: `points`, `depth`, `normal`, `mask`, `metric_scale`. We center-crop
+/// the input UIImage to a square, run inference, and return:
+///
+///   - depth in metric meters (= raw_depth × metric_scale)
+///   - per-pixel surface normals in [-1, 1]
+///   - confidence mask in [0, 1]
+///
+/// Visualization (turbo colormap, normal RGB) lives on the View side.
+final class DepthEstimator: ObservableObject {
+    static let inputSize = 504
+
+    private var mlModel: MLModel?
+    @Published var isReady = false
+
+    struct Result {
+        let depth: [Float]          // size*size, in meters
+        let normal: [Float]         // size*size*3, last dim packed [nx, ny, nz]
+        let mask: [Float]           // size*size, in [0, 1]
+        let metricScale: Float
+        let depthMin: Float
+        let depthMax: Float
+        let size: Int
+        // Letterbox: the valid region within the 504x504 output.
+        let validX: Int
+        let validY: Int
+        let validW: Int
+        let validH: Int
+    }
+
+    init() {
+        loadModel()
+    }
+
+    private func loadModel() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self, let resourcePath = Bundle.main.resourcePath else { return }
+            let fm = FileManager.default
+            guard let items = try? fm.contentsOfDirectory(atPath: resourcePath) else { return }
+            let config = MLModelConfiguration()
+            // Pure ViT, runs comfortably on ANE at 504x504; .all picks the best path.
+            config.computeUnits = .all
+            for item in items where item.hasSuffix(".mlmodelc") && item.contains("MoGe2") {
+                let url = URL(fileURLWithPath: (resourcePath as NSString).appendingPathComponent(item))
+                if let model = try? MLModel(contentsOf: url, configuration: config) {
+                    self.mlModel = model
+                    DispatchQueue.main.async { self.isReady = true }
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - Inference
+
+    func estimate(image: UIImage) async throws -> Result {
+        guard let model = mlModel else { throw EstimatorError.modelNotLoaded }
+        let fixed = image.normalizedOrientation()
+        guard let cgImage = fixed.cgImage else { throw EstimatorError.invalidImage }
+
+        let (letterboxed, validRect) = letterboxCGImage(cgImage, targetSize: Self.inputSize)
+
+        let pixelBuffer = try makeBGRAPixelBuffer(from: letterboxed)
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "image": MLFeatureValue(pixelBuffer: pixelBuffer)
+        ])
+        let output = try await model.prediction(from: input)
+
+        guard
+            let depthArr = output.featureValue(for: "depth")?.multiArrayValue,
+            let normalArr = output.featureValue(for: "normal")?.multiArrayValue,
+            let maskArr = output.featureValue(for: "mask")?.multiArrayValue,
+            let scaleArr = output.featureValue(for: "metric_scale")?.multiArrayValue
+        else {
+            throw EstimatorError.predictionFailed
+        }
+
+        let metricScale = scaleArr[0].floatValue
+
+        // depth: (1, H, W) — strides may not be C-contiguous on ANE.
+        let depth = readMultiArray2D(depthArr, height: Self.inputSize, width: Self.inputSize)
+        let mask = readMultiArray2D(maskArr, height: Self.inputSize, width: Self.inputSize)
+        // normal: (1, H, W, 3)
+        let normal = readMultiArray3D(normalArr, height: Self.inputSize, width: Self.inputSize, channels: 3)
+
+        // Apply mask × metric_scale to depth, ignoring the background.
+        var metricDepth = [Float](repeating: 0, count: depth.count)
+        var dMin: Float = .greatestFiniteMagnitude
+        var dMax: Float = 0
+        for i in 0..<depth.count {
+            let valid = mask[i] > 0.5
+            let d = valid ? depth[i] * metricScale : 0
+            metricDepth[i] = d
+            if valid {
+                if d < dMin { dMin = d }
+                if d > dMax { dMax = d }
+            }
+        }
+        if dMin == .greatestFiniteMagnitude { dMin = 0 }
+
+        return Result(
+            depth: metricDepth,
+            normal: normal,
+            mask: mask,
+            metricScale: metricScale,
+            depthMin: dMin,
+            depthMax: dMax,
+            size: Self.inputSize,
+            validX: validRect.x,
+            validY: validRect.y,
+            validW: validRect.w,
+            validH: validRect.h
+        )
+    }
+
+    // MARK: - Output reading (stride-aware)
+
+    /// Read a (1, H, W) MLMultiArray into a row-major Float buffer.
+    /// Uses vImageConvert row-by-row to handle ANE stride padding + FP16→FP32.
+    private func readMultiArray2D(_ array: MLMultiArray, height: Int, width: Int) -> [Float] {
+        let strides = array.strides.map { $0.intValue }
+        let rowStride = strides[1]
+        var result = [Float](repeating: 0, count: height * width)
+
+        if array.dataType == .float16 {
+            let src = array.dataPointer.assumingMemoryBound(to: UInt16.self)
+            result.withUnsafeMutableBufferPointer { dst in
+                for r in 0..<height {
+                    var srcBuf = vImage_Buffer(
+                        data: UnsafeMutableRawPointer(mutating: src + r * rowStride),
+                        height: 1, width: vImagePixelCount(width), rowBytes: width * 2
+                    )
+                    var dstBuf = vImage_Buffer(
+                        data: dst.baseAddress! + r * width,
+                        height: 1, width: vImagePixelCount(width), rowBytes: width * 4
+                    )
+                    vImageConvert_Planar16FtoPlanarF(&srcBuf, &dstBuf, 0)
+                }
+            }
+        } else {
+            let src = array.dataPointer.assumingMemoryBound(to: Float.self)
+            result.withUnsafeMutableBufferPointer { dst in
+                for r in 0..<height {
+                    memcpy(dst.baseAddress! + r * width, src + r * rowStride, width * 4)
+                }
+            }
+        }
+        return result
+    }
+
+    /// Read a (1, H, W, C) MLMultiArray into a row-major Float buffer of size H*W*C.
+    /// For FP16 with colStride == C and chStride == 1, converts each row in bulk.
+    private func readMultiArray3D(_ array: MLMultiArray, height: Int, width: Int, channels: Int) -> [Float] {
+        let strides = array.strides.map { $0.intValue }
+        let rowStride = strides[1]
+        let colStride = strides[2]
+        let chStride = strides[3]
+        let rowElements = width * channels
+        var result = [Float](repeating: 0, count: height * width * channels)
+
+        let interleaved = (colStride == channels && chStride == 1)
+
+        if array.dataType == .float16 {
+            let src = array.dataPointer.assumingMemoryBound(to: UInt16.self)
+            if interleaved {
+                // Fast path: each row is contiguous [w*C] FP16 values.
+                result.withUnsafeMutableBufferPointer { dst in
+                    for r in 0..<height {
+                        var srcBuf = vImage_Buffer(
+                            data: UnsafeMutableRawPointer(mutating: src + r * rowStride),
+                            height: 1, width: vImagePixelCount(rowElements), rowBytes: rowElements * 2
+                        )
+                        var dstBuf = vImage_Buffer(
+                            data: dst.baseAddress! + r * rowElements,
+                            height: 1, width: vImagePixelCount(rowElements), rowBytes: rowElements * 4
+                        )
+                        vImageConvert_Planar16FtoPlanarF(&srcBuf, &dstBuf, 0)
+                    }
+                }
+            } else {
+                // Fallback: per-element
+                for r in 0..<height {
+                    let baseR = r * rowStride
+                    for c in 0..<width {
+                        let baseC = baseR + c * colStride
+                        let dst = (r * width + c) * channels
+                        for ch in 0..<channels {
+                            result[dst + ch] = Float(Float16(bitPattern: src[baseC + ch * chStride]))
+                        }
+                    }
+                }
+            }
+        } else {
+            let src = array.dataPointer.assumingMemoryBound(to: Float.self)
+            if interleaved {
+                result.withUnsafeMutableBufferPointer { dst in
+                    for r in 0..<height {
+                        memcpy(dst.baseAddress! + r * rowElements, src + r * rowStride, rowElements * 4)
+                    }
+                }
+            } else {
+                for r in 0..<height {
+                    let baseR = r * rowStride
+                    for c in 0..<width {
+                        let baseC = baseR + c * colStride
+                        let dst = (r * width + c) * channels
+                        for ch in 0..<channels {
+                            result[dst + ch] = src[baseC + ch * chStride]
+                        }
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    // MARK: - Image helpers
+
+    struct ValidRect { let x: Int; let y: Int; let w: Int; let h: Int }
+
+    /// Letterbox: resize the image so the long side fits `targetSize`, then
+    /// center it on a black `targetSize × targetSize` canvas. Returns the
+    /// composited CGImage and the rect describing where the actual image pixels
+    /// landed (so we can crop the model output back to the original aspect ratio).
+    private func letterboxCGImage(_ image: CGImage, targetSize: Int) -> (CGImage, ValidRect) {
+        let srcW = image.width
+        let srcH = image.height
+        let scale = Float(targetSize) / Float(max(srcW, srcH))
+        let dstW = Int((Float(srcW) * scale).rounded())
+        let dstH = Int((Float(srcH) * scale).rounded())
+        let padX = (targetSize - dstW) / 2
+        let padY = (targetSize - dstH) / 2
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(
+            data: nil, width: targetSize, height: targetSize,
+            bitsPerComponent: 8, bytesPerRow: targetSize * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        // Canvas is zero-initialized (black).
+        ctx.interpolationQuality = .high
+        ctx.draw(image, in: CGRect(x: padX, y: padY, width: dstW, height: dstH))
+        return (ctx.makeImage()!, ValidRect(x: padX, y: padY, w: dstW, h: dstH))
+    }
+
+    /// Build a kCVPixelFormatType_32BGRA CVPixelBuffer that the CoreML
+    /// ImageType input accepts directly (the converter applies scale=1/255 +
+    /// RGB layout for us, so we just have to deliver pixels).
+    private func makeBGRAPixelBuffer(from image: CGImage) throws -> CVPixelBuffer {
+        let w = image.width
+        let h = image.height
+        let attrs: [String: Any] = [
+            kCVPixelBufferCGImageCompatibilityKey as String: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey as String: true,
+        ]
+        var pb: CVPixelBuffer?
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault, w, h,
+            kCVPixelFormatType_32BGRA,
+            attrs as CFDictionary, &pb
+        )
+        guard status == kCVReturnSuccess, let buffer = pb else {
+            throw EstimatorError.pixelBufferAllocFailed
+        }
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+        let ctx = CGContext(
+            data: CVPixelBufferGetBaseAddress(buffer),
+            width: w, height: h,
+            bitsPerComponent: 8,
+            bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+        )
+        ctx?.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+        return buffer
+    }
+}
+
+extension UIImage {
+    func normalizedOrientation() -> UIImage {
+        guard imageOrientation != .up else { return self }
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        draw(in: CGRect(origin: .zero, size: size))
+        let normalized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return normalized ?? self
+    }
+}
+
+enum EstimatorError: LocalizedError {
+    case invalidImage, modelNotLoaded, predictionFailed, pixelBufferAllocFailed
+    var errorDescription: String? {
+        switch self {
+        case .invalidImage: return "Invalid image"
+        case .modelNotLoaded: return "Model not loaded"
+        case .predictionFailed: return "Inference failed"
+        case .pixelBufferAllocFailed: return "Pixel buffer allocation failed"
+        }
+    }
+}

--- a/sample_apps/MoGe2Demo/MoGe2Demo/Info.plist
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/sample_apps/MoGe2Demo/MoGe2Demo/MoGe2DemoApp.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/MoGe2DemoApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MoGe2DemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/sample_apps/MoGe2Demo/MoGe2Demo/Visualization.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/Visualization.swift
@@ -1,0 +1,81 @@
+import UIKit
+
+/// Visualization helpers: turbo colormap for depth, RGB encoding for normals.
+/// All methods accept the full 504x504 model output and a valid rect that
+/// describes where the actual image content sits (letterbox region). The
+/// returned UIImage is cropped to the valid rect so it matches the original
+/// aspect ratio.
+enum Visualization {
+
+    /// Render a metric depth map as a turbo-colormap UIImage.
+    static func depthImage(
+        _ depth: [Float], size: Int, dMin: Float, dMax: Float,
+        validX: Int, validY: Int, validW: Int, validH: Int
+    ) -> UIImage {
+        var rgba = [UInt8](repeating: 0, count: validW * validH * 4)
+        let span = max(dMax - dMin, 1e-3)
+        for row in 0..<validH {
+            let srcRow = (validY + row) * size + validX
+            let dstRow = row * validW
+            for col in 0..<validW {
+                let d = depth[srcRow + col]
+                if d <= 0 { continue }
+                let t = min(max((d - dMin) / span, 0), 1)
+                let (r, g, b) = turbo(1 - t)
+                let idx = (dstRow + col) * 4
+                rgba[idx] = UInt8(r * 255)
+                rgba[idx + 1] = UInt8(g * 255)
+                rgba[idx + 2] = UInt8(b * 255)
+                rgba[idx + 3] = 255
+            }
+        }
+        return makeUIImage(rgba: rgba, width: validW, height: validH)
+    }
+
+    /// Render surface normals as an RGB image.
+    static func normalImage(
+        _ normal: [Float], mask: [Float], size: Int,
+        validX: Int, validY: Int, validW: Int, validH: Int
+    ) -> UIImage {
+        var rgba = [UInt8](repeating: 0, count: validW * validH * 4)
+        for row in 0..<validH {
+            let srcRow = (validY + row) * size + validX
+            let dstRow = row * validW
+            for col in 0..<validW {
+                let si = srcRow + col
+                if mask[si] < 0.5 { continue }
+                let nx = normal[si * 3]
+                let ny = -normal[si * 3 + 1]
+                let nz = normal[si * 3 + 2]
+                let idx = (dstRow + col) * 4
+                rgba[idx] = UInt8(((nx + 1) * 0.5 * 255).rounded())
+                rgba[idx + 1] = UInt8(((ny + 1) * 0.5 * 255).rounded())
+                rgba[idx + 2] = UInt8(((nz + 1) * 0.5 * 255).rounded())
+                rgba[idx + 3] = 255
+            }
+        }
+        return makeUIImage(rgba: rgba, width: validW, height: validH)
+    }
+
+    // MARK: - Turbo colormap (Mikhailov 2019)
+    private static func turbo(_ t: Float) -> (Float, Float, Float) {
+        let x = min(max(t, 0), 1)
+        let r =  0.13572138 + x * ( 4.61539260 + x * (-42.66032258 + x * (132.13108234 + x * (-152.94239396 + x *  59.28637943))))
+        let g =  0.09140261 + x * ( 2.19418839 + x * (  4.84296658 + x * (-14.18503333 + x * (  4.27729857 + x *   2.82956604))))
+        let b =  0.10667330 + x * (12.64194608 + x * (-60.58204836 + x * (110.36276771 + x * ( -89.90310912 + x *  27.34824973))))
+        return (min(max(r, 0), 1), min(max(g, 0), 1), min(max(b, 0), 1))
+    }
+
+    private static func makeUIImage(rgba: [UInt8], width: Int, height: Int) -> UIImage {
+        var data = rgba
+        let ctx = CGContext(
+            data: &data,
+            width: width, height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        return UIImage(cgImage: ctx.makeImage()!)
+    }
+}

--- a/sample_apps/MoGe2Demo/README.md
+++ b/sample_apps/MoGe2Demo/README.md
@@ -12,8 +12,8 @@ This demo uses the **MoGe-2 ViT-B + normal** variant (104 M parameters) at a fix
 
 ## Setup
 
-1. Build the mlpackage from [`conversion_scripts/convert_moge2.py`](../../conversion_scripts/convert_moge2.py)
-2. Drop `MoGe2_ViTB_Normal_504.mlpackage` into the Xcode project
+1. Download [MoGe2_ViTB_Normal_504.mlpackage.zip](https://github.com/john-rocky/CoreML-Models/releases/download/moge2-v1/MoGe2_ViTB_Normal_504.mlpackage.zip) (or build from [`conversion_scripts/convert_moge2.py`](../../conversion_scripts/convert_moge2.py))
+2. Unzip and drop `MoGe2_ViTB_Normal_504.mlpackage` into the Xcode project
 3. Build and run on a physical device (iOS 17+)
 
 ## Conversion Notes

--- a/sample_apps/MoGe2Demo/README.md
+++ b/sample_apps/MoGe2Demo/README.md
@@ -1,0 +1,46 @@
+# MoGe2Demo
+
+Sample iOS app for [microsoft/MoGe](https://github.com/microsoft/MoGe) (CVPR 2025 Oral) — open-domain monocular 3D geometry estimation. Given a single photo it predicts a metric depth map, surface normals, and a confidence mask in one forward pass on a DINOv2 ViT-B backbone with three task heads.
+
+This demo uses the **MoGe-2 ViT-B + normal** variant (104 M parameters) at a fixed 504 × 504 input. The CoreML model is one self-contained mlpackage (~200 MB at FP16) that returns five tensors: `points`, `depth`, `normal`, `mask`, `metric_scale`.
+
+## Models
+
+| Module | Inputs | Outputs |
+|---|---|---|
+| `MoGe2_ViTB_Normal_504` | image [1, 3, 504, 504] in [0, 1] | points [1, 504, 504, 3], depth [1, 504, 504], normal [1, 504, 504, 3], mask [1, 504, 504], metric_scale [1] |
+
+## Setup
+
+1. Build the mlpackage from [`conversion_scripts/convert_moge2.py`](../../conversion_scripts/convert_moge2.py)
+2. Drop `MoGe2_ViTB_Normal_504.mlpackage` into the Xcode project
+3. Build and run on a physical device (iOS 17+)
+
+## Conversion Notes
+
+- **DINOv2 backbone with a frozen pos_embed.** The stock DINOv2 `interpolate_pos_encoding` does a bicubic + antialias resize of the pretrained positional embedding every forward call. coremltools cannot trace bicubic + antialias cleanly. The converter pre-computes the interpolated pos_embed once for the fixed 36 × 36 token grid and replaces the method with a constant lookup, so the traced graph never hits bicubic interpolation.
+- **`onnx_compatible_mode = True`** disables the antialias path in `DINOv2Encoder.forward` as well, leaving only bilinear `F.interpolate` calls that coremltools handles natively.
+- **Aspect-ratio-aware num_tokens path is collapsed.** MoGeModel computes `base_h, base_w` at runtime from `(num_tokens, aspect_ratio)`. The wrapper hard-codes `base_h = base_w = 36` (= 504 / 14) so the trace sees Python ints all the way through.
+- **Pyramid features and UV grids are pre-computed**. `normalized_view_plane_uv` for each of the 5 levels is registered as a non-persistent buffer at wrapper construction time, so the converted graph contains no `linspace` / `meshgrid` ops.
+- **`int` op patch for multi-dim shape casts** is required (same as SinSR / Swin Transformer). DINOv2's positional indexing emits int casts on a 2-element shape tensor that the stock coremltools converter assumes are scalars. The patched op accepts both.
+- **Outputs match MoGeModel.forward with `remap_output='exp'`** baked in (the wrapper inlines the `xy * z, z = exp(z)` remap so Swift just receives the final `(B, H, W, 3)` point map plus a depth slice).
+- **Focal / shift / intrinsics recovery is left to the Swift driver.** The CoreML model returns the affine point map plus `metric_scale`; the demo app applies the scale and ignores any focal-shift refinement (good enough for visualization). For metric SLAM-style use you would port `recover_focal_shift` to Swift.
+- **FP16 throughout.** DINOv2 ViT attention does not overflow at this resolution; FP16 + `.cpuAndNeuralEngine` runs comfortably on iPhone 15 / 17. Real-image parity vs the PyTorch reference is ~1 % relative on depth and < 6° on surface normals.
+
+## Inference Pipeline (Swift)
+
+1. Center-crop the photo to a square, resize to 504 × 504.
+2. Wrap in a BGRA `CVPixelBuffer` (the model's `ImageType` input applies `scale = 1/255` automatically).
+3. Run `MLModel.prediction`. Read `depth`, `normal`, `mask`, `metric_scale` with **stride-aware** access (the ANE returns non-contiguous strides — see Basic Pitch in `docs/coreml_conversion_notes.md`).
+4. Mask out background pixels and multiply depth by `metric_scale` to get meters.
+5. Render: turbo colormap for depth (near = warm), surface-normal RGB for normals (`nx, -ny, nz` → `r, g, b`).
+
+## Conversion Script
+
+[`conversion_scripts/convert_moge2.py`](../../conversion_scripts/convert_moge2.py)
+
+```bash
+python convert_moge2.py                                    # ViT-B normal, 504×504
+python convert_moge2.py --variant vits-normal --size 392   # smaller / faster
+python convert_moge2.py --variant vitl-normal --size 504   # higher quality, ~660 MB
+```


### PR DESCRIPTION
## Summary

- **MoGe-2 ViT-B + normal** (microsoft/MoGe, CVPR 2025 Oral) converted to a single FP16 CoreML mlpackage (~200 MB, 504×504 fixed input)
- Predicts metric depth (in meters), surface normals, and confidence mask in one forward pass from a DINOv2 ViT-B/14 backbone with 3 task heads
- SwiftUI demo app (`sample_apps/MoGe2Demo/`) with turbo colormap depth visualization, normal-map RGB rendering, and metric depth range readout
- Conversion script (`conversion_scripts/convert_moge2.py`) supporting ViT-S/B/L variants and optional INT8 quantization

## Key implementation details

### Conversion (Python)
- Frozen DINOv2 positional embedding (bicubic+antialias → constant lookup) for clean tracing
- `onnx_compatible_mode=True` + `enable_pytorch_native_sdpa()` for coremltools compatibility
- Pre-computed UV grids as register buffers for all 5 pyramid levels
- coremltools `int` op patch for multi-dim shape casts (same as SinSR)
- Parity vs PyTorch reference: ~0.6% relative on depth, <6° worst-pixel on normals

### iOS App (Swift)
- Letterbox preprocessing (long-side fit + black padding) preserving original aspect ratio
- Stride-aware FP16 MLMultiArray readout via `vImageConvert_Planar16FtoPlanarF` (ANE pads rows to 512)
- Valid-rect cropping on visualization output to restore original aspect ratio
- Tested on iPhone, ~0.28s inference + ~0.09s readout

### Documentation
- `docs/coreml_conversion_notes.md`: DINOv2 Backbone Conversion Checklist (reusable for Depth Anything V2, Marigold, etc.)
- `sample_apps/MoGe2Demo/README.md`: setup, architecture, conversion notes
- `README.md`: MoGe-2 entry under Monocular Depth Estimation

## Files

| Path | Description |
|---|---|
| `conversion_scripts/convert_moge2.py` | PyTorch → CoreML converter (vitb/vits/vitl, configurable resolution) |
| `sample_apps/MoGe2Demo/` | SwiftUI demo app (iOS 17+) |
| `sample_apps/MoGe2Demo/README.md` | Per-app documentation |
| `docs/coreml_conversion_notes.md` | DINOv2 conversion checklist added |
| `README.md` | MoGe-2 section added |
| `.gitignore` | Vendored `conversion_scripts/MoGe/` excluded |

## Setup

```bash
# 1. Clone upstream into conversion_scripts/
cd conversion_scripts && git clone --depth 1 https://github.com/microsoft/MoGe.git

# 2. Convert (requires torch, coremltools>=9.0, utils3d)
python3.12 convert_moge2.py

# 3. Drop mlpackage into the Xcode project, build on device
```

## Test plan

- [x] Conversion parity verified (random + real image, max abs err within FP16 tolerance)
- [x] iOS device test: inference runs, depth/normal visualization correct
- [x] FP16 MLMultiArray readout crash fixed (Float16 pointer + vImage)
- [x] Letterbox preprocessing preserves aspect ratio
- [ ] Upload mlpackage zip to GitHub Releases