### PR TITLE
Add Language Model section (CoreML-LLM / Gemma 4 E2B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ You are free to do or not.
 - [**Vision-Language**](#vision-language)
   - [Florence-2-base](#florence-2-base)
 
+- [**Language Model**](#language-model)
+  - [Gemma 4 E2B (CoreML-LLM)](#gemma-4-e2b-coreml-llm)
+
 - [**Zero-Shot Image Classification**](#zero-shot-image-classification)
   - [SigLIP ViT-B/16](#siglip-vit-b16)
 
@@ -1047,6 +1050,20 @@ Microsoft Florence-2 — a unified vision-language model supporting image captio
 | Download Link | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
 | [Florence2VisionEncoder](https://github.com/john-rocky/CoreML-Models/releases/download/florence2-v1/Florence2VisionEncoder.mlpackage.zip) / [TextEncoder](https://github.com/john-rocky/CoreML-Models/releases/download/florence2-v1/Florence2TextEncoder.mlpackage.zip) / [Decoder](https://github.com/john-rocky/CoreML-Models/releases/download/florence2-v1/Florence2Decoder.mlpackage.zip) | 260 MB (INT8, 3 models total) | 768x768 RGB image + task prompt | Generated text (caption, OCR, etc.) | [microsoft/Florence-2-base](https://huggingface.co/microsoft/Florence-2-base) | [MIT](https://huggingface.co/microsoft/Florence-2-base/blob/main/LICENSE) | 2024 | [Florence2Demo](sample_apps/Florence2Demo) | [convert_florence2.py](conversion_scripts/convert_florence2.py) |
+
+# Language Model
+
+### Gemma 4 E2B (CoreML-LLM)
+
+**[john-rocky/CoreML-LLM](https://github.com/john-rocky/CoreML-LLM)** — Companion repository for running LLMs on the **Apple Neural Engine**. Unlike MLX Swift (GPU-only), CoreML-LLM targets ANE for ~10x lower power draw, making always-on on-device LLMs practical on iPhone.
+
+Google Gemma 4 E2B (2B params) running on iPhone 15 Pro at ~11 tok/s decode and ~175 tok/s effective prefill throughput (seq=64 batched prefill → 188 ms TTFT for a 33-token prompt). INT4 palettized, 2048 context length, Sliding Window Attention (28/35 layers are O(W)), Per-Layer Embedding computed inside the ANE graph.
+
+| Download Link | Size | Input | Output | Original Project | License | Year | Sample Project | Swift Package |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| [mlboydaisuke/gemma-4-E2B-coreml](https://huggingface.co/mlboydaisuke/gemma-4-E2B-coreml) | 2.7 GB (INT4, 4 decode + 4 prefill chunks) | Text prompt (up to 2048 tokens) | Generated text (streaming) | [google/gemma-3n-E2B-it](https://huggingface.co/google/gemma-3n-E2B-it) | [Gemma ToU](https://ai.google.dev/gemma/terms) | 2025 | [CoreMLLLMChat](https://github.com/john-rocky/CoreML-LLM/tree/main/Examples/CoreMLLLMChat) | [CoreML-LLM](https://github.com/john-rocky/CoreML-LLM) |
+
+See [CoreML-LLM](https://github.com/john-rocky/CoreML-LLM) for the full conversion pipeline, ANE optimization techniques (cat-trick RMSNorm, Conv2d Linear, pre-computed RoPE, stateless KV with explicit I/O), and the Swift sample app.
 
 # Zero-Shot Image Classification
 


### PR DESCRIPTION
## Summary
- New **Language Model** section pointing to [john-rocky/CoreML-LLM](https://github.com/john-rocky/CoreML-LLM)
- Positions CoreML-LLM as the ANE-targeted counterpart to MLX Swift (GPU) for always-on, low-power on-device LLM use
- Links to the pre-converted Gemma 4 E2B on HuggingFace and the iOS sample app

## Context
CoreML-LLM v0.2.0 was released today with batched prefill (seq=64, 188 ms TTFT on iPhone 15 Pro for a 33-token prompt) and Sliding Window Attention, enabling Gemma 4 E2B at 2048 context length on iPhone with ~11 tok/s decode and ~175 tok/s effective prefill.

This PR only touches README.md — no sample app or model files are added here; the work lives in the companion repo.

## Test plan
- [x] Preview renders correctly (TOC + section match the existing table style)
- [x] All links resolve (HF model, CoreML-LLM repo, sample app, Gemma ToU)