### PR TITLE
Add Depth Anything 3 (Small / Base) Core ML conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ models_draft.json
 
 # Vendored upstream repos (clone from README link, do not commit)
 conversion_scripts/MoGe/
+conversion_scripts/DepthAnythingV3/

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You are free to do or not.
   - [Lama](#lama)
 
 - [**Monocular Depth Estimation**](#monocular-depth-estimation)
+  - [Depth Anything 3](#depth-anything-3)
   - [MoGe-2](#moge-2)
   - [MiDaS](#midas)
   
@@ -881,6 +882,15 @@ White-box facial image cartoonizaiton
 |[Lama](https://drive.google.com/drive/folders/1s_uICJQykFFxgVubpBNeLLDL0JsxgdCd?usp=sharing)|216.6MB| Image (Color 800 × 800), Image (GrayScale 800 × 800)| Image (Color 800 × 800) |[advimman/lama](https://github.com/advimman/lama)|[Apache2.0](https://github.com/advimman/lama/blob/main/LICENSE)|To use see sample.| [john-rocky/lama-cleaner-iOS](https://github.com/john-rocky/lama-cleaner-iOS) | [mallman/CoreMLaMa](https://github.com/mallman/CoreMLaMa)|
 
 # Monocular Depth Estimation
+
+### Depth Anything 3
+
+[ByteDance-Seed/Depth-Anything-3](https://github.com/ByteDance-Seed/Depth-Anything-3) (ICLR 2026 Oral) — relative monocular depth from a single image. DA3 Main Series uses a plain DINOv2 ViT backbone plus a DualDPT head with a unified depth-ray representation; this Core ML port exposes only the monocular depth + confidence subgraph (camera / multi-view / sky / 3DGS branches are stripped). First public Core ML conversion of DA3.
+
+| Module | Size | Input | Output | Original Project | License | Year | Sample Project | Conversion Script |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [DA3 Small 504×504](https://huggingface.co/mlboydaisuke/coreml-zoo/resolve/main/depth_anything_v3/DepthAnythingV3_small_504.mlpackage.zip) | ~44 MB FP16 | Image (RGB 504 × 504) | depth + confidence | [ByteDance-Seed/Depth-Anything-3](https://github.com/ByteDance-Seed/Depth-Anything-3) | [Apache 2.0](https://github.com/ByteDance-Seed/Depth-Anything-3/blob/main/LICENSE) | 2025 | Hub App | [convert_depth_anything_v3.py](conversion_scripts/convert_depth_anything_v3.py) |
+| [DA3 Base 504×504](https://huggingface.co/mlboydaisuke/coreml-zoo/resolve/main/depth_anything_v3/DepthAnythingV3_base_504.mlpackage.zip) | ~173 MB FP16 | Image (RGB 504 × 504) | depth + confidence | [ByteDance-Seed/Depth-Anything-3](https://github.com/ByteDance-Seed/Depth-Anything-3) | [Apache 2.0](https://github.com/ByteDance-Seed/Depth-Anything-3/blob/main/LICENSE) | 2025 | Hub App | [convert_depth_anything_v3.py](conversion_scripts/convert_depth_anything_v3.py) |
 
 ### MoGe-2
 

--- a/conversion_scripts/convert_depth_anything_v3.py
+++ b/conversion_scripts/convert_depth_anything_v3.py
@@ -1,0 +1,416 @@
+"""
+Convert Depth Anything 3 (ByteDance-Seed, ICLR'26 oral) to Core ML.
+
+This script targets the monocular depth subgraph of the DA3 Main Series.
+Default variant is DA3-Small (Apache 2.0, 0.08B params, DINOv2 ViT-S/14 +
+DualDPT head). The multi-view, camera, ray, sky and Gaussian branches are
+intentionally dropped — we only need single-image relative depth for iOS.
+
+Wrapper:
+  - Takes (1, 3, H, W) RGB in [0, 255]; ImageNet normalization is baked in.
+  - Unsqueezes to (1, 1, 3, H, W) so the upstream B, S, 3, H, W signature
+    keeps working (S=1 for monocular).
+  - Freezes the bicubic-interpolated DINOv2 positional embedding for the
+    fixed token grid (same pattern as convert_moge2.py).
+  - Replaces the in-place camera-token write inside the backbone
+    (`x[:, :, 0] = cam_token`) with a torch.cat equivalent so torch.jit.trace
+    captures a clean graph.
+  - Returns (depth, conf) with shape (1, H, W) each, squeezed of the S=1
+    batch dimension.
+
+Usage:
+  python convert_depth_anything_v3.py                    # DA3-Small, 504x504
+  python convert_depth_anything_v3.py --size 518
+  python convert_depth_anything_v3.py --output DA3_Small_504.mlpackage
+"""
+import argparse
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+import coremltools as ct
+from coremltools.converters.mil.frontend.torch import ops as _ct_ops
+from coremltools.converters.mil import Builder as mb
+
+REPO = Path(__file__).resolve().parent / "DepthAnythingV3" / "src"
+sys.path.insert(0, str(REPO))
+
+# Bypass depth_anything_3.api entirely — it pulls in moviepy / pycolmap / evo
+# / trimesh / gsplat for optional GLB / 3DGS / COLMAP export, none of which
+# are needed to trace the model. Load the net directly from config + HF
+# safetensors.
+from depth_anything_3.cfg import create_object, load_config  # noqa: E402
+from depth_anything_3.registry import MODEL_REGISTRY  # noqa: E402
+from depth_anything_3.model.da3 import DepthAnything3Net  # noqa: E402
+from huggingface_hub import hf_hub_download  # noqa: E402
+from safetensors.torch import load_file as load_safetensors  # noqa: E402
+
+
+# ============================================================
+# coremltools 9.0 patch: `int` op for multi-dim shape casts.
+# Same patch as convert_moge2.py / convert_sinsr.py.
+# ============================================================
+
+def _patched_int(context, node):
+    inputs = _ct_ops._get_inputs(context, node)
+    x = inputs[0]
+    if x.val is not None:
+        val = x.val
+        if isinstance(val, np.ndarray):
+            val = int(val.item()) if val.ndim == 0 else int(val.flat[0])
+        else:
+            val = int(val)
+        res = mb.const(val=np.int32(val), name=node.name)
+    else:
+        res = mb.cast(x=x, dtype="int32", name=node.name)
+    context.add(res)
+
+
+_ct_ops._TORCH_OPS_REGISTRY.register_func(_patched_int, torch_alias=["int"], override=True)
+
+
+# ============================================================
+# Replace torch.meshgrid-based UV grid (coremltools trips on it) with
+# an explicit broadcast+stack that is trace-friendly.
+# ============================================================
+
+def _coreml_safe_create_uv_grid(
+    width: int,
+    height: int,
+    aspect_ratio: float = None,
+    dtype: torch.dtype = None,
+    device: torch.device = None,
+) -> torch.Tensor:
+    if aspect_ratio is None:
+        aspect_ratio = float(width) / float(height)
+    diag_factor = (aspect_ratio ** 2 + 1.0) ** 0.5
+    span_x = aspect_ratio / diag_factor
+    span_y = 1.0 / diag_factor
+    left_x = -span_x * (width - 1) / width
+    right_x = span_x * (width - 1) / width
+    top_y = -span_y * (height - 1) / height
+    bottom_y = span_y * (height - 1) / height
+    x_coords = torch.linspace(left_x, right_x, steps=width, dtype=dtype, device=device)
+    y_coords = torch.linspace(top_y, bottom_y, steps=height, dtype=dtype, device=device)
+    # Equivalent to torch.meshgrid(x_coords, y_coords, indexing="xy") +
+    # stack(dim=-1): output is (height, width, 2), [..., 0] = x, [..., 1] = y.
+    uu = x_coords.view(1, width).expand(height, width)
+    vv = y_coords.view(height, 1).expand(height, width)
+    return torch.stack((uu, vv), dim=-1)
+
+
+def patch_head_utils():
+    """Swap the meshgrid-based create_uv_grid with the trace-friendly one.
+    DualDPT._add_pos_embed imports it directly, so we replace the symbol on
+    the module it was imported into as well."""
+    from depth_anything_3.model.utils import head_utils as _hu
+    from depth_anything_3.model import dualdpt as _dualdpt
+    _hu.create_uv_grid = _coreml_safe_create_uv_grid
+    _dualdpt.create_uv_grid = _coreml_safe_create_uv_grid
+
+
+# ============================================================
+# Freeze DINOv2 positional embedding
+# ============================================================
+
+def freeze_pos_embed(backbone, base_h: int, base_w: int) -> None:
+    """Bake the bicubic pos_embed interpolation as a constant buffer."""
+    img_h, img_w = base_h * backbone.patch_size, base_w * backbone.patch_size
+    dummy = torch.zeros(1, 3, img_h, img_w)
+    tokens = backbone.patch_embed(dummy)
+    cls = backbone.cls_token.expand(tokens.shape[0], -1, -1)
+    x = torch.cat([cls, tokens], dim=1)
+    with torch.no_grad():
+        pos = backbone.interpolate_pos_encoding(x, img_h, img_w)
+    backbone.register_buffer("_frozen_pos_embed", pos.detach().clone(), persistent=False)
+
+    def _frozen_interp(self, x, h, w):  # noqa: ARG001
+        return self._frozen_pos_embed
+
+    backbone.interpolate_pos_encoding = types.MethodType(_frozen_interp, backbone)
+
+
+# ============================================================
+# Freeze RoPE 2D position grid
+# ============================================================
+
+def freeze_rope_positions(backbone, base_h: int, base_w: int) -> None:
+    """Pre-compute the RoPE position grid (uses `torch.cartesian_prod` which
+    coremltools does not implement) and stash it as a buffer, then replace
+    `_prepare_rope` with a constant lookup."""
+    if backbone.rope is None:
+        return
+
+    y = torch.arange(base_h)
+    x = torch.arange(base_w)
+    # (base_h * base_w, 2) y-x coordinates, matching PositionGetter.
+    positions = torch.stack(torch.meshgrid(y, x, indexing="ij"), dim=-1).reshape(-1, 2)
+    # Add the cls / camera / register token slot at the front.
+    # Shape (1, N + patch_start_idx, 2). Values: special tokens all zeros,
+    # patch tokens indexed from 1 (matches vision_transformer _prepare_rope).
+    patch_start_idx = backbone.patch_start_idx
+    pos_patches = (positions + 1).unsqueeze(0)  # (1, N, 2)
+    pos_special = torch.zeros(1, patch_start_idx, 2, dtype=positions.dtype)
+    pos_full = torch.cat([pos_special, pos_patches], dim=1)  # (1, N + pat, 2)
+    pos_nodiff_full = torch.cat(
+        [pos_special, torch.ones(1, positions.shape[0], 2, dtype=positions.dtype)], dim=1
+    )
+
+    # (B, S, N + pat, 2) — for our monocular wrapper B=S=1 so we can drop
+    # the extra dims and broadcast.
+    pos_full = pos_full.unsqueeze(1)  # (1, 1, N+pat, 2)
+    pos_nodiff_full = pos_nodiff_full.unsqueeze(1)
+
+    backbone.register_buffer("_frozen_rope_pos", pos_full.detach().clone(), persistent=False)
+    backbone.register_buffer(
+        "_frozen_rope_pos_nodiff", pos_nodiff_full.detach().clone(), persistent=False
+    )
+
+    def _frozen_prepare_rope(self, B, S, H, W, device):  # noqa: ARG001
+        return self._frozen_rope_pos, self._frozen_rope_pos_nodiff
+
+    backbone._prepare_rope = types.MethodType(_frozen_prepare_rope, backbone)
+
+
+# ============================================================
+# Replace in-place camera-token write with torch.cat
+# ============================================================
+
+def patch_backbone_forward(backbone):
+    """Monkey-patch `_get_intermediate_layers_not_chunked` to avoid the
+    in-place slice assignment at alt_start, which traces poorly.
+
+    Also hard-codes the S=1 path — reference-view reordering never fires for
+    S<3 and the tail `'b_idx' in locals()` check is unreachable.
+    """
+    import torch as _torch
+
+    def _patched(self, x, n=1, export_feat_layers=[], **kwargs):
+        B, S, _, H, W = x.shape
+        x = self.prepare_tokens_with_masks(x)
+        output, total_block_len, aux_output = [], len(self.blocks), []
+        blocks_to_take = (
+            range(total_block_len - n, total_block_len) if isinstance(n, int) else n
+        )
+        pos, pos_nodiff = self._prepare_rope(B, S, H, W, x.device)
+
+        local_x = x
+        for i, blk in enumerate(self.blocks):
+            if i < self.rope_start or self.rope is None:
+                g_pos, l_pos = None, None
+            else:
+                g_pos = pos_nodiff
+                l_pos = pos
+
+            if self.alt_start != -1 and i == self.alt_start:
+                # Build camera token — for S=1 just take the reference slot.
+                if kwargs.get("cam_token", None) is not None:
+                    cam_token = kwargs.get("cam_token")
+                else:
+                    ref_token = self.camera_token[:, :1].expand(B, -1, -1)
+                    if S > 1:
+                        src_token = self.camera_token[:, 1:].expand(B, S - 1, -1)
+                        cam_token = _torch.cat([ref_token, src_token], dim=1)
+                    else:
+                        cam_token = ref_token
+                # Replace the in-place `x[:, :, 0] = cam_token` with cat.
+                # x: (B, S, N, C), cam_token: (B, S, C)
+                cam_token = cam_token.unsqueeze(2)  # (B, S, 1, C)
+                x = _torch.cat([cam_token, x[:, :, 1:]], dim=2)
+
+            if self.alt_start != -1 and i >= self.alt_start and i % 2 == 1:
+                x = self.process_attention(
+                    x, blk, "global", pos=g_pos, attn_mask=kwargs.get("attn_mask", None)
+                )
+            else:
+                x = self.process_attention(x, blk, "local", pos=l_pos)
+                local_x = x
+
+            if i in blocks_to_take:
+                out_x = _torch.cat([local_x, x], dim=-1) if self.cat_token else x
+                output.append((out_x[:, :, 0], out_x))
+            if i in export_feat_layers:
+                aux_output.append(x)
+        return output, aux_output
+
+    backbone._get_intermediate_layers_not_chunked = types.MethodType(_patched, backbone)
+
+
+# ============================================================
+# Wrapper
+# ============================================================
+
+# ImageNet normalization constants (from DA3 input_processor).
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+class MonoDepthWrapper(nn.Module):
+    """Stateless wrapper around DepthAnything3Net that only exposes the
+    monocular depth head. Input is RGB in [0, 1]; ImageNet normalization is
+    applied inside the wrapper so Core ML can use a simple ImageType(scale).
+    """
+
+    def __init__(self, net: DepthAnything3Net, size: int):
+        super().__init__()
+        assert size % 14 == 0, f"size must be a multiple of 14, got {size}"
+        self.net = net
+        self.size = size
+
+        mean = torch.tensor(_IMAGENET_MEAN).view(1, 3, 1, 1)
+        std = torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1)
+        self.register_buffer("mean", mean, persistent=False)
+        self.register_buffer("std", std, persistent=False)
+
+    def forward(self, image: torch.Tensor):
+        # image: (1, 3, H, W) in [0, 1]
+        x = (image - self.mean) / self.std
+        x = x.unsqueeze(1)  # (B, 1, 3, H, W) — S=1 monocular
+
+        # Backbone. Pass cam_token=None so the monkey-patched branch builds
+        # it from the learnt `camera_token` parameter.
+        feats, _aux = self.net.backbone(
+            x, cam_token=None, export_feat_layers=[], ref_view_strategy="first"
+        )
+
+        # DualDPT head — returns dict with depth + depth_conf (+ aux ray+conf).
+        out = self.net.head(feats, self.size, self.size, patch_start_idx=0)
+
+        # depth / conf come back as (B=1, S=1, H, W). Squeeze S.
+        depth = out.depth.squeeze(1)
+        conf = out.depth_conf.squeeze(1)
+        return depth, conf
+
+
+# ============================================================
+# Main
+# ============================================================
+
+VARIANTS = {
+    # variant key -> (HF repo id, config name in MODEL_REGISTRY)
+    "small": ("depth-anything/DA3-SMALL", "da3-small"),
+    "base": ("depth-anything/DA3-BASE", "da3-base"),
+    "large": ("depth-anything/DA3-LARGE-1.1", "da3-large"),
+    "mono-large": ("depth-anything/DA3MONO-LARGE", "da3mono-large"),
+}
+
+
+def load_net(repo_id: str, config_name: str) -> DepthAnything3Net:
+    """Build DepthAnything3Net from its yaml config and load safetensors
+    weights directly from HF. Avoids importing depth_anything_3.api."""
+    cfg_path = MODEL_REGISTRY[config_name]
+    print(f"        config: {cfg_path}")
+    net = create_object(load_config(cfg_path))
+    net.eval()
+
+    ckpt_path = hf_hub_download(repo_id, filename="model.safetensors")
+    print(f"        checkpoint: {ckpt_path}")
+    state = load_safetensors(ckpt_path)
+
+    # DepthAnything3 stores the inner net under self.model.*, so strip that
+    # prefix if present.
+    if any(k.startswith("model.") for k in state):
+        state = {k[len("model."):]: v for k, v in state.items() if k.startswith("model.")}
+    missing, unexpected = net.load_state_dict(state, strict=False)
+    if missing:
+        print(f"        missing keys: {len(missing)} (first 3: {missing[:3]})")
+    if unexpected:
+        print(f"        unexpected keys: {len(unexpected)} (first 3: {unexpected[:3]})")
+    return net
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--variant", default="small", choices=list(VARIANTS.keys()))
+    p.add_argument("--size", type=int, default=504, help="square input size (multiple of 14)")
+    p.add_argument("--output", type=str, default=None)
+    p.add_argument("--quantize", action="store_true", help="apply INT8 weight quant")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    repo_id, cfg_name = VARIANTS[args.variant]
+    print(f"[1/5] Loading DepthAnything3 from {repo_id} (config: {cfg_name})")
+    net = load_net(repo_id, cfg_name)
+    backbone = net.backbone.pretrained  # DinoVisionTransformer
+
+    assert args.size % backbone.patch_size == 0, (
+        f"size={args.size} must be a multiple of patch={backbone.patch_size}"
+    )
+    base = args.size // backbone.patch_size
+
+    print("[2-/5] Swapping create_uv_grid to avoid torch.meshgrid in trace")
+    patch_head_utils()
+
+    print(f"[2/5] Freezing pos_embed for {args.size}x{args.size} ({base}x{base} tokens)")
+    freeze_pos_embed(backbone, base, base)
+
+    print("[2b/5] Freezing RoPE position grid (cartesian_prod is unsupported in CoreML)")
+    freeze_rope_positions(backbone, base, base)
+
+    print("[2c/5] Patching backbone forward to remove in-place camera-token write")
+    patch_backbone_forward(backbone)
+
+    print("[3/5] Building wrapper and tracing")
+    wrapper = MonoDepthWrapper(net, args.size).eval()
+    example = torch.rand(1, 3, args.size, args.size)
+    with torch.no_grad():
+        ref_depth, ref_conf = wrapper(example)
+        print(f"        eager depth: {ref_depth.shape}, conf: {ref_conf.shape}")
+        print(f"        depth range: [{ref_depth.min().item():.3e}, {ref_depth.max().item():.3e}]")
+
+        traced = torch.jit.trace(wrapper, example, strict=False)
+        t_depth, t_conf = traced(example)
+        for name, ref, got in [("depth", ref_depth, t_depth), ("conf", ref_conf, t_conf)]:
+            err = (ref - got).abs().max().item()
+            print(f"        trace parity {name:6s}: max abs err = {err:.3e}")
+            assert err < 1e-3, f"trace parity broke for {name}: {err}"
+
+    print("[4/5] Converting to Core ML")
+    mlmodel = ct.convert(
+        traced,
+        inputs=[
+            ct.ImageType(
+                name="image",
+                shape=(1, 3, args.size, args.size),
+                scale=1.0 / 255.0,
+                color_layout=ct.colorlayout.RGB,
+            )
+        ],
+        outputs=[
+            ct.TensorType(name="depth"),
+            ct.TensorType(name="confidence"),
+        ],
+        compute_precision=ct.precision.FLOAT16,
+        minimum_deployment_target=ct.target.iOS17,
+        convert_to="mlprogram",
+    )
+
+    if args.quantize:
+        print("        applying INT8 weight quantization")
+        from coremltools.optimize.coreml import (
+            OpLinearQuantizerConfig,
+            OptimizationConfig,
+            linear_quantize_weights,
+        )
+        cfg = OptimizationConfig(
+            global_config=OpLinearQuantizerConfig(mode="linear_symmetric", dtype="int8")
+        )
+        mlmodel = linear_quantize_weights(mlmodel, cfg)
+
+    out_path = (
+        args.output
+        or f"DepthAnythingV3_{args.variant.replace('-', '_')}_{args.size}.mlpackage"
+    )
+    print(f"[5/5] Saving to {out_path}")
+    mlmodel.save(out_path)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Info.plist
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Info.plist
@@ -8,5 +8,7 @@
     <string>Microphone access is needed for speech and audio model demos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Photo library access is needed to pick images and videos to run models on.</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>Save model outputs (annotated photos, depth maps, generated images) back to your photo library.</string>
 </dict>
 </plist>

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
@@ -5,6 +5,14 @@ import CoreML
 struct DepthVisualizationDemoView: View {
     let model: ModelEntry
 
+    enum Mode: String, CaseIterable, Identifiable {
+        case camera = "Camera", photo = "Photo"
+        var id: String { rawValue }
+    }
+
+    @State private var mode: Mode = .photo
+
+    // Photo-mode state
     @State private var inputImage: UIImage?
     @State private var depthImage: UIImage?
     @State private var normalImage: UIImage?
@@ -15,6 +23,15 @@ struct DepthVisualizationDemoView: View {
     @State private var isProcessing = false
     @State private var status = ""
     @State private var item: PhotosPickerItem?
+
+    // Camera-mode state. `mlModel` is cached on load so the per-frame
+    // callback can run prediction without awaiting the session.
+    @State private var mlModel: MLModel?
+    @State private var liveDepth: UIImage?
+    @State private var liveFps: Double = 0
+    @State private var isInferring = false
+    @State private var frameSkip = 0
+
     @StateObject private var session = ModelSession<MLModel>()
 
     enum ViewMode: String, CaseIterable, Identifiable {
@@ -30,12 +47,56 @@ struct DepthVisualizationDemoView: View {
         return modes
     }
 
+    private var currentDisplayImage: UIImage? {
+        switch viewMode {
+        case .original: return inputImage
+        case .depth: return depthImage
+        case .normal: return normalImage
+        case .confidence: return confidenceImage
+        }
+    }
+
     // "meters", "relative", or nil. Controls the range label unit suffix.
     private var depthUnit: String {
         model.configString("depth_unit") ?? "meters"
     }
 
     var body: some View {
+        VStack(spacing: 0) {
+            Picker("Mode", selection: $mode) {
+                ForEach(Mode.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal).padding(.top, 4)
+
+            ZStack {
+                switch mode {
+                case .camera: cameraContent
+                case .photo: photoContent
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            if mode == .photo {
+                photoControls
+            } else {
+                cameraControls
+            }
+        }
+        .task { await loadModel() }
+        .onChange(of: item) { _, _ in loadAndRun() }
+        .onChange(of: mode) { _, _ in
+            liveDepth = nil
+            liveFps = 0
+            frameSkip = 0
+        }
+        .onDisappear { mlModel = nil }
+    }
+
+    // MARK: - Photo mode
+
+    @ViewBuilder
+    private var photoContent: some View {
         VStack(spacing: 0) {
             displayArea.frame(maxHeight: .infinity)
 
@@ -45,51 +106,13 @@ struct DepthVisualizationDemoView: View {
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
-
-                HStack {
-                    if depthRange.max > 0 {
-                        let format = depthUnit == "meters"
-                            ? "Depth: %.2f – %.2f m"
-                            : "Depth (relative): %.2f – %.2f"
-                        Text(String(format: format, depthRange.min, depthRange.max))
-                            .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    TimingsLabel(loadSec: session.loadTimeSec, inferSec: processingTime)
-                }
-                .padding(.horizontal)
             }
-
-            VStack(spacing: 12) {
-                if isProcessing { ProgressView(status) }
-                Text(status).font(.caption).foregroundStyle(.secondary)
-                PhotosPicker(selection: $item, matching: .images) {
-                    Label("Select Photo", systemImage: "photo.badge.plus").frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-            }
-            .padding()
-        }
-        .task {
-            session.ensure { try await ModelLoader.loadPrimary(for: model) }
-        }
-        .onChange(of: item) { _, newItem in
-            print("[Depth] onChange fired, newItem=\(String(describing: newItem))")
-            loadAndRun()
         }
     }
 
     @ViewBuilder
     private var displayArea: some View {
-        let img: UIImage? = {
-            switch viewMode {
-            case .original: return inputImage
-            case .depth: return depthImage
-            case .normal: return normalImage
-            case .confidence: return confidenceImage
-            }
-        }()
-        if let img {
+        if let img = currentDisplayImage {
             Image(uiImage: img).resizable().aspectRatio(contentMode: .fit)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
@@ -102,31 +125,128 @@ struct DepthVisualizationDemoView: View {
         }
     }
 
-    private func loadAndRun() {
-        guard let item else {
-            print("[Depth] loadAndRun: item is nil, returning")
-            return
+    @ViewBuilder
+    private var photoControls: some View {
+        VStack(spacing: 8) {
+            HStack {
+                if depthRange.max > 0 {
+                    let format = depthUnit == "meters"
+                        ? "Depth: %.2f – %.2f m"
+                        : "Depth (relative): %.2f – %.2f"
+                    Text(String(format: format, depthRange.min, depthRange.max))
+                        .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+                }
+                Spacer()
+                TimingsLabel(loadSec: session.loadTimeSec, inferSec: processingTime)
+            }
+            .padding(.horizontal)
+
+            if isProcessing { ProgressView(status) }
+            if !status.isEmpty { Text(status).font(.caption).foregroundStyle(.secondary) }
+
+            HStack(spacing: 12) {
+                PhotosPicker(selection: $item, matching: .images) {
+                    Label("Select Photo", systemImage: "photo.badge.plus").frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+
+                if viewMode != .original, let img = currentDisplayImage {
+                    Button {
+                        UIImageWriteToSavedPhotosAlbum(img, nil, nil, nil)
+                    } label: {
+                        Image(systemName: "arrow.down.to.line")
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
         }
-        print("[Depth] loadAndRun: starting with item=\(item)")
+        .padding()
+    }
+
+    // MARK: - Camera mode
+
+    @ViewBuilder
+    private var cameraContent: some View {
+        ZStack {
+            CameraView(position: .back) { pb in
+                processCameraFrame(pb)
+            }
+            .opacity(liveDepth == nil ? 1 : 0.001)
+
+            if let depth = liveDepth {
+                Image(uiImage: depth).resizable().aspectRatio(contentMode: .fit)
+            }
+
+            if mlModel == nil {
+                ProgressView("Loading model…").tint(.white).padding(16)
+                    .background(.ultraThinMaterial).clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var cameraControls: some View {
+        HStack {
+            Text(String(format: "%.1f FPS", liveFps))
+                .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+            Spacer()
+            TimingsLabel(loadSec: session.loadTimeSec, inferSec: nil)
+        }
+        .padding(.horizontal).padding(.vertical, 8)
+    }
+
+    // MARK: - Model loading
+
+    private func loadModel() async {
+        session.ensure { try await ModelLoader.loadPrimary(for: model) }
+        do {
+            let loaded = try await session.get()
+            await MainActor.run { mlModel = loaded }
+        } catch {
+            await MainActor.run { status = "Load failed: \(error.localizedDescription)" }
+        }
+    }
+
+    // MARK: - Camera frame pipeline
+
+    // Runs on the CameraView output queue. Skips when an inference is already
+    // in flight so frames don't pipeline and blow memory.
+    private func processCameraFrame(_ pb: CVPixelBuffer) {
+        guard let mlModel, !isInferring else { return }
+        frameSkip += 1
+        guard frameSkip % 2 == 0 else { return }
+        isInferring = true
+
+        let inputSize = model.configInt("input_size") ?? 504
+
+        Task.detached(priority: .userInitiated) {
+            let start = CFAbsoluteTimeGetCurrent()
+            let heatmap = runLiveDepth(pixelBuffer: pb, mlModel: mlModel, inputSize: inputSize)
+            let elapsed = CFAbsoluteTimeGetCurrent() - start
+            await MainActor.run {
+                if heatmap != nil { liveDepth = heatmap }
+                let fps = 1.0 / max(elapsed, 0.001)
+                liveFps = liveFps == 0 ? fps : liveFps * 0.9 + fps * 0.1
+                isInferring = false
+            }
+        }
+    }
+
+    // MARK: - Photo inference
+
+    private func loadAndRun() {
+        guard let item else { return }
         isProcessing = true; status = "Loading photo…"
         Task {
             do {
-                guard let data = try await item.loadTransferable(type: Data.self) else {
-                    print("[Depth] loadTransferable returned nil")
-                    await MainActor.run { isProcessing = false; status = "Photo load returned nil" }
-                    return
-                }
-                print("[Depth] Got data: \(data.count) bytes")
-                guard let img = UIImage(data: data) else {
-                    print("[Depth] UIImage(data:) failed")
+                guard let data = try await item.loadTransferable(type: Data.self),
+                      let img = UIImage(data: data) else {
                     await MainActor.run { isProcessing = false; status = "Invalid image data" }
                     return
                 }
-                print("[Depth] Image loaded: \(img.size)")
                 await MainActor.run { inputImage = img }
                 await runDepth(on: img)
             } catch {
-                print("[Depth] loadTransferable error: \(error)")
                 await MainActor.run { isProcessing = false; status = "Load error: \(error.localizedDescription)" }
             }
         }
@@ -139,41 +259,24 @@ struct DepthVisualizationDemoView: View {
             await MainActor.run { status = "Running inference…" }
 
             let inputSize = model.configInt("input_size") ?? 504
-            print("[Depth] inputSize=\(inputSize)")
             guard let cgImage = ImageUtils.normalizeOrientation(image) else {
-                print("[Depth] normalizeOrientation failed")
                 await MainActor.run { isProcessing = false; status = "Image prep failed" }
                 return
             }
-            print("[Depth] cgImage: \(cgImage.width)x\(cgImage.height)")
 
-            guard let (pb, validRect) = ImageUtils.letterbox(cgImage, size: inputSize) else {
-                print("[Depth] letterbox failed")
+            guard let (pb, _) = ImageUtils.letterbox(cgImage, size: inputSize) else {
                 await MainActor.run { isProcessing = false; status = "Letterbox failed" }
                 return
             }
-            print("[Depth] Letterbox done, validRect=\(validRect)")
 
-            // Find image input name
             let inputName = mlModel.modelDescription.inputDescriptionsByName.first {
                 $0.value.type == .image
             }?.key ?? "image"
-            print("[Depth] Using input name: \(inputName)")
 
             let start = CFAbsoluteTimeGetCurrent()
             let input = try MLDictionaryFeatureProvider(dictionary: [inputName: pb])
             let output = try await mlModel.prediction(from: input)
             let elapsed = CFAbsoluteTimeGetCurrent() - start
-            print("[Depth] Inference done in \(elapsed)s, output keys: \(output.featureNames)")
-
-            // Extract outputs
-            for name in output.featureNames {
-                if let arr = output.featureValue(for: name)?.multiArrayValue {
-                    print("[Depth] output '\(name)': shape=\(arr.shape), dtype=\(arr.dataType.rawValue)")
-                } else {
-                    print("[Depth] output '\(name)': not a multiarray")
-                }
-            }
 
             let depthArr = output.featureValue(for: "depth")?.multiArrayValue
             let normalArr = output.featureValue(for: "normal")?.multiArrayValue
@@ -181,67 +284,23 @@ struct DepthVisualizationDemoView: View {
             let scaleArr = output.featureValue(for: "metric_scale")?.multiArrayValue
             let confArr = output.featureValue(for: "confidence")?.multiArrayValue
 
-            print("[Depth] depthArr=\(depthArr != nil), normalArr=\(normalArr != nil), maskArr=\(maskArr != nil), scaleArr=\(scaleArr != nil), confArr=\(confArr != nil)")
-
             let metricScale: Float = scaleArr.map { ImageUtils.readFloat($0, at: 0) } ?? 1.0
-            print("[Depth] metricScale=\(metricScale)")
 
-            // Build depth heatmap
             var depthResult: UIImage?
             var dMin: Float = 0, dMax: Float = 0
             if let depthArr {
-                let shape = depthArr.shape.map { $0.intValue }
-                let strides = depthArr.strides.map { $0.intValue }
-                print("[Depth] depth shape=\(shape), strides=\(strides)")
-                let h = shape.count == 3 ? shape[1] : shape[2]
-                let w = shape.count == 3 ? shape[2] : shape[3]
-                let hS = shape.count == 3 ? strides[1] : strides[2]
-                let wS = shape.count == 3 ? strides[2] : strides[3]
-
-                var depthValues = [Float](repeating: 0, count: h * w)
-                for y in 0..<h {
-                    for x in 0..<w {
-                        var v = ImageUtils.readFloat(depthArr, at: y * hS + x * wS)
-                        v *= metricScale
-                        if let maskArr {
-                            let mv = ImageUtils.readFloat(maskArr, at: y * hS + x * wS)
-                            if mv < 0.5 { v = 0 }
-                        }
-                        depthValues[y * w + x] = v
-                    }
-                }
-                dMin = depthValues.filter { $0 > 0 }.min() ?? 0
-                dMax = depthValues.filter { $0 > 0 }.max() ?? 0
-                print("[Depth] depth range: \(dMin) – \(dMax)")
-                depthResult = ImageUtils.heatmapFromDepth(depthValues, width: w, height: h)
-                print("[Depth] heatmap: \(depthResult != nil)")
+                let (heatmap, minV, maxV) = buildDepthHeatmap(
+                    depthArr: depthArr, maskArr: maskArr, metricScale: metricScale
+                )
+                depthResult = heatmap
+                dMin = minV; dMax = maxV
             }
 
-            // Build normal map
             var normalResult: UIImage?
-            if let normalArr {
-                normalResult = ImageUtils.normalMapImage(normalArr)
-                print("[Depth] normalMap: \(normalResult != nil)")
-            }
+            if let normalArr { normalResult = ImageUtils.normalMapImage(normalArr) }
 
-            // Build confidence heatmap (normalized to [0, 1] across the image).
             var confResult: UIImage?
-            if let confArr {
-                let shape = confArr.shape.map { $0.intValue }
-                let strides = confArr.strides.map { $0.intValue }
-                let h = shape.count == 3 ? shape[1] : shape[2]
-                let w = shape.count == 3 ? shape[2] : shape[3]
-                let hS = shape.count == 3 ? strides[1] : strides[2]
-                let wS = shape.count == 3 ? strides[2] : strides[3]
-                var vals = [Float](repeating: 0, count: h * w)
-                for y in 0..<h {
-                    for x in 0..<w {
-                        vals[y * w + x] = ImageUtils.readFloat(confArr, at: y * hS + x * wS)
-                    }
-                }
-                confResult = ImageUtils.heatmapFromDepth(vals, width: w, height: h)
-                print("[Depth] confidence heatmap: \(confResult != nil)")
-            }
+            if let confArr { confResult = buildConfidenceHeatmap(confArr) }
 
             await MainActor.run {
                 depthImage = depthResult
@@ -251,13 +310,101 @@ struct DepthVisualizationDemoView: View {
                 processingTime = elapsed
                 if viewMode == .normal && normalResult == nil { viewMode = .depth }
                 if viewMode == .confidence && confResult == nil { viewMode = .depth }
-                processingTime = elapsed
                 isProcessing = false; status = ""
-                print("[Depth] UI updated. depthImage=\(depthResult != nil), normalImage=\(normalResult != nil), confidenceImage=\(confResult != nil)")
             }
         } catch {
-            print("[Depth] ERROR: \(error)")
             await MainActor.run { isProcessing = false; status = "Error: \(error.localizedDescription)" }
         }
+    }
+
+    // MARK: - Heatmap helpers (shared between photo and camera)
+
+    private func buildDepthHeatmap(
+        depthArr: MLMultiArray, maskArr: MLMultiArray?, metricScale: Float
+    ) -> (UIImage?, Float, Float) {
+        let shape = depthArr.shape.map { $0.intValue }
+        let strides = depthArr.strides.map { $0.intValue }
+        let h = shape.count == 3 ? shape[1] : shape[2]
+        let w = shape.count == 3 ? shape[2] : shape[3]
+        let hS = shape.count == 3 ? strides[1] : strides[2]
+        let wS = shape.count == 3 ? strides[2] : strides[3]
+
+        var depthValues = [Float](repeating: 0, count: h * w)
+        for y in 0..<h {
+            for x in 0..<w {
+                var v = ImageUtils.readFloat(depthArr, at: y * hS + x * wS)
+                v *= metricScale
+                if let maskArr {
+                    let mv = ImageUtils.readFloat(maskArr, at: y * hS + x * wS)
+                    if mv < 0.5 { v = 0 }
+                }
+                depthValues[y * w + x] = v
+            }
+        }
+        let dMin = depthValues.filter { $0 > 0 }.min() ?? 0
+        let dMax = depthValues.filter { $0 > 0 }.max() ?? 0
+        let heatmap = ImageUtils.heatmapFromDepth(depthValues, width: w, height: h)
+        return (heatmap, dMin, dMax)
+    }
+
+    private func buildConfidenceHeatmap(_ confArr: MLMultiArray) -> UIImage? {
+        let shape = confArr.shape.map { $0.intValue }
+        let strides = confArr.strides.map { $0.intValue }
+        let h = shape.count == 3 ? shape[1] : shape[2]
+        let w = shape.count == 3 ? shape[2] : shape[3]
+        let hS = shape.count == 3 ? strides[1] : strides[2]
+        let wS = shape.count == 3 ? strides[2] : strides[3]
+        var vals = [Float](repeating: 0, count: h * w)
+        for y in 0..<h {
+            for x in 0..<w {
+                vals[y * w + x] = ImageUtils.readFloat(confArr, at: y * hS + x * wS)
+            }
+        }
+        return ImageUtils.heatmapFromDepth(vals, width: w, height: h)
+    }
+}
+
+// MARK: - Live depth (detached)
+
+// Runs off the main actor so the CameraView queue isn't blocked by CoreImage
+// + the Swift heatmap loop. `mlModel.prediction` is thread-safe.
+private func runLiveDepth(pixelBuffer: CVPixelBuffer, mlModel: MLModel, inputSize: Int) -> UIImage? {
+    let ci = CIImage(cvPixelBuffer: pixelBuffer)
+    let ctx = CIContext(options: [.useSoftwareRenderer: false])
+    guard let cg = ctx.createCGImage(ci, from: ci.extent) else { return nil }
+    guard let (pb, _) = ImageUtils.letterbox(cg, size: inputSize) else { return nil }
+
+    let inputName = mlModel.modelDescription.inputDescriptionsByName.first {
+        $0.value.type == .image
+    }?.key ?? "image"
+
+    do {
+        let input = try MLDictionaryFeatureProvider(dictionary: [inputName: pb])
+        let output = try mlModel.prediction(from: input)
+
+        guard let depthArr = output.featureValue(for: "depth")?.multiArrayValue else { return nil }
+        let maskArr = output.featureValue(for: "mask")?.multiArrayValue
+
+        let shape = depthArr.shape.map { $0.intValue }
+        let strides = depthArr.strides.map { $0.intValue }
+        let h = shape.count == 3 ? shape[1] : shape[2]
+        let w = shape.count == 3 ? shape[2] : shape[3]
+        let hS = shape.count == 3 ? strides[1] : strides[2]
+        let wS = shape.count == 3 ? strides[2] : strides[3]
+
+        var depthValues = [Float](repeating: 0, count: h * w)
+        for y in 0..<h {
+            for x in 0..<w {
+                var v = ImageUtils.readFloat(depthArr, at: y * hS + x * wS)
+                if let maskArr {
+                    let mv = ImageUtils.readFloat(maskArr, at: y * hS + x * wS)
+                    if mv < 0.5 { v = 0 }
+                }
+                depthValues[y * w + x] = v
+            }
+        }
+        return ImageUtils.heatmapFromDepth(depthValues, width: w, height: h)
+    } catch {
+        return nil
     }
 }

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
@@ -8,6 +8,7 @@ struct DepthVisualizationDemoView: View {
     @State private var inputImage: UIImage?
     @State private var depthImage: UIImage?
     @State private var normalImage: UIImage?
+    @State private var confidenceImage: UIImage?
     @State private var depthRange: (min: Float, max: Float) = (0, 0)
     @State private var processingTime: Double?
     @State private var viewMode: ViewMode = .depth
@@ -17,9 +18,21 @@ struct DepthVisualizationDemoView: View {
     @StateObject private var session = ModelSession<MLModel>()
 
     enum ViewMode: String, CaseIterable, Identifiable {
-        case original, depth, normal
+        case original, depth, normal, confidence
         var id: String { rawValue }
         var label: String { rawValue.capitalized }
+    }
+
+    private var availableModes: [ViewMode] {
+        var modes: [ViewMode] = [.original, .depth]
+        if normalImage != nil { modes.append(.normal) }
+        if confidenceImage != nil { modes.append(.confidence) }
+        return modes
+    }
+
+    // "meters", "relative", or nil. Controls the range label unit suffix.
+    private var depthUnit: String {
+        model.configString("depth_unit") ?? "meters"
     }
 
     var body: some View {
@@ -28,14 +41,17 @@ struct DepthVisualizationDemoView: View {
 
             if depthImage != nil {
                 Picker("View", selection: $viewMode) {
-                    ForEach(ViewMode.allCases) { Text($0.label).tag($0) }
+                    ForEach(availableModes) { Text($0.label).tag($0) }
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
 
                 HStack {
                     if depthRange.max > 0 {
-                        Text(String(format: "Depth: %.2f – %.2f m", depthRange.min, depthRange.max))
+                        let format = depthUnit == "meters"
+                            ? "Depth: %.2f – %.2f m"
+                            : "Depth (relative): %.2f – %.2f"
+                        Text(String(format: format, depthRange.min, depthRange.max))
                             .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
                     }
                     Spacer()
@@ -70,6 +86,7 @@ struct DepthVisualizationDemoView: View {
             case .original: return inputImage
             case .depth: return depthImage
             case .normal: return normalImage
+            case .confidence: return confidenceImage
             }
         }()
         if let img {
@@ -162,8 +179,9 @@ struct DepthVisualizationDemoView: View {
             let normalArr = output.featureValue(for: "normal")?.multiArrayValue
             let maskArr = output.featureValue(for: "mask")?.multiArrayValue
             let scaleArr = output.featureValue(for: "metric_scale")?.multiArrayValue
+            let confArr = output.featureValue(for: "confidence")?.multiArrayValue
 
-            print("[Depth] depthArr=\(depthArr != nil), normalArr=\(normalArr != nil), maskArr=\(maskArr != nil), scaleArr=\(scaleArr != nil)")
+            print("[Depth] depthArr=\(depthArr != nil), normalArr=\(normalArr != nil), maskArr=\(maskArr != nil), scaleArr=\(scaleArr != nil), confArr=\(confArr != nil)")
 
             let metricScale: Float = scaleArr.map { ImageUtils.readFloat($0, at: 0) } ?? 1.0
             print("[Depth] metricScale=\(metricScale)")
@@ -206,13 +224,36 @@ struct DepthVisualizationDemoView: View {
                 print("[Depth] normalMap: \(normalResult != nil)")
             }
 
+            // Build confidence heatmap (normalized to [0, 1] across the image).
+            var confResult: UIImage?
+            if let confArr {
+                let shape = confArr.shape.map { $0.intValue }
+                let strides = confArr.strides.map { $0.intValue }
+                let h = shape.count == 3 ? shape[1] : shape[2]
+                let w = shape.count == 3 ? shape[2] : shape[3]
+                let hS = shape.count == 3 ? strides[1] : strides[2]
+                let wS = shape.count == 3 ? strides[2] : strides[3]
+                var vals = [Float](repeating: 0, count: h * w)
+                for y in 0..<h {
+                    for x in 0..<w {
+                        vals[y * w + x] = ImageUtils.readFloat(confArr, at: y * hS + x * wS)
+                    }
+                }
+                confResult = ImageUtils.heatmapFromDepth(vals, width: w, height: h)
+                print("[Depth] confidence heatmap: \(confResult != nil)")
+            }
+
             await MainActor.run {
                 depthImage = depthResult
                 normalImage = normalResult
+                confidenceImage = confResult
                 depthRange = (dMin, dMax)
                 processingTime = elapsed
+                if viewMode == .normal && normalResult == nil { viewMode = .depth }
+                if viewMode == .confidence && confResult == nil { viewMode = .depth }
+                processingTime = elapsed
                 isProcessing = false; status = ""
-                print("[Depth] UI updated. depthImage=\(depthResult != nil), normalImage=\(normalResult != nil)")
+                print("[Depth] UI updated. depthImage=\(depthResult != nil), normalImage=\(normalResult != nil), confidenceImage=\(confResult != nil)")
             }
         } catch {
             print("[Depth] ERROR: \(error)")

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
@@ -1,12 +1,13 @@
 import SwiftUI
 import PhotosUI
 import CoreML
+import AVFoundation
 
 struct DepthVisualizationDemoView: View {
     let model: ModelEntry
 
     enum Mode: String, CaseIterable, Identifiable {
-        case camera = "Camera", photo = "Photo"
+        case camera = "Camera", video = "Video", photo = "Photo"
         var id: String { rawValue }
     }
 
@@ -31,6 +32,11 @@ struct DepthVisualizationDemoView: View {
     @State private var liveFps: Double = 0
     @State private var isInferring = false
     @State private var frameSkip = 0
+
+    // Video-mode state
+    @State private var videoItem: PhotosPickerItem?
+    @State private var videoProgress: Double = 0
+    @State private var videoTask: Task<Void, Never>?
 
     @StateObject private var session = ModelSession<MLModel>()
 
@@ -72,25 +78,36 @@ struct DepthVisualizationDemoView: View {
             ZStack {
                 switch mode {
                 case .camera: cameraContent
+                case .video: videoContent
                 case .photo: photoContent
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            if mode == .photo {
-                photoControls
-            } else {
-                cameraControls
-            }
+            modeControls
         }
         .task { await loadModel() }
         .onChange(of: item) { _, _ in loadAndRun() }
-        .onChange(of: mode) { _, _ in
+        .onChange(of: videoItem) { _, _ in loadAndProcessVideo() }
+        .onChange(of: mode) { _, newMode in
             liveDepth = nil
             liveFps = 0
             frameSkip = 0
+            if newMode != .video { videoTask?.cancel() }
         }
-        .onDisappear { mlModel = nil }
+        .onDisappear {
+            videoTask?.cancel()
+            mlModel = nil
+        }
+    }
+
+    @ViewBuilder
+    private var modeControls: some View {
+        switch mode {
+        case .photo: photoControls
+        case .camera: cameraControls
+        case .video: videoControls
+        }
     }
 
     // MARK: - Photo mode
@@ -193,6 +210,46 @@ struct DepthVisualizationDemoView: View {
             TimingsLabel(loadSec: session.loadTimeSec, inferSec: nil)
         }
         .padding(.horizontal).padding(.vertical, 8)
+    }
+
+    // MARK: - Video mode
+
+    @ViewBuilder
+    private var videoContent: some View {
+        ZStack {
+            if let depth = liveDepth {
+                Image(uiImage: depth).resizable().aspectRatio(contentMode: .fit)
+            } else {
+                VStack(spacing: 12) {
+                    Image(systemName: "film").font(.system(size: 60)).foregroundStyle(.secondary)
+                    Text("Select a video to run depth frame-by-frame").foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var videoControls: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text(String(format: "%.1f FPS", liveFps))
+                    .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+                Spacer()
+                TimingsLabel(loadSec: session.loadTimeSec, inferSec: nil)
+            }
+            .padding(.horizontal)
+
+            if liveDepth != nil {
+                ProgressView(value: videoProgress).tint(.blue).padding(.horizontal)
+            }
+
+            PhotosPicker(selection: $videoItem, matching: .videos) {
+                Label("Select Video", systemImage: "video.badge.plus").frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .padding(.horizontal)
+        }
+        .padding(.vertical, 8)
     }
 
     // MARK: - Model loading
@@ -317,6 +374,33 @@ struct DepthVisualizationDemoView: View {
         }
     }
 
+    // MARK: - Video pipeline
+
+    private func loadAndProcessVideo() {
+        videoTask?.cancel()
+        guard let videoItem else { return }
+        liveDepth = nil; liveFps = 0; videoProgress = 0
+        Task {
+            guard let transferable = try? await videoItem.loadTransferable(type: DepthVideoTransferable.self) else {
+                await MainActor.run { status = "Failed to load video" }
+                return
+            }
+            let url = transferable.url
+            let inputSize = model.configInt("input_size") ?? 504
+            guard let mlModel else { return }
+            videoTask = Task.detached(priority: .userInitiated) {
+                await runDepthVideo(url: url, mlModel: mlModel, inputSize: inputSize) { frame, progress, fps in
+                    Task { @MainActor in
+                        liveDepth = frame
+                        videoProgress = progress
+                        liveFps = liveFps == 0 ? fps : liveFps * 0.9 + fps * 0.1
+                    }
+                }
+                await MainActor.run { videoProgress = 1.0 }
+            }
+        }
+    }
+
     // MARK: - Heatmap helpers (shared between photo and camera)
 
     private func buildDepthHeatmap(
@@ -361,6 +445,67 @@ struct DepthVisualizationDemoView: View {
             }
         }
         return ImageUtils.heatmapFromDepth(vals, width: w, height: h)
+    }
+}
+
+// MARK: - Video transferable
+
+struct DepthVideoTransferable: Transferable {
+    let url: URL
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(contentType: .movie) { movie in
+            SentTransferredFile(movie.url)
+        } importing: { received in
+            let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(
+                UUID().uuidString + "." + received.file.pathExtension)
+            try FileManager.default.copyItem(at: received.file, to: tmp)
+            return Self(url: tmp)
+        }
+    }
+}
+
+// MARK: - Video depth (detached)
+
+// Streams a picked video through the depth model. Cooperative cancellation via
+// Task.isCancelled lets the view abort when the user switches modes or picks
+// another clip; callback fires on every decoded frame for UI updates.
+private func runDepthVideo(
+    url: URL,
+    mlModel: MLModel,
+    inputSize: Int,
+    onFrame: @escaping (UIImage, Double, Double) -> Void
+) async {
+    let asset = AVURLAsset(url: url)
+    guard let track = try? await asset.loadTracks(withMediaType: .video).first else { return }
+    let duration = try? await asset.load(.duration)
+    let totalSeconds = duration.map { CMTimeGetSeconds($0) } ?? 1
+    let nominalFPS = (try? await track.load(.nominalFrameRate)) ?? 30
+    let frameInterval = 1.0 / Double(nominalFPS)
+
+    guard let reader = try? AVAssetReader(asset: asset) else { return }
+    let outputSettings: [String: Any] = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+    let trackOutput = AVAssetReaderTrackOutput(track: track, outputSettings: outputSettings)
+    reader.add(trackOutput)
+    reader.startReading()
+
+    while !Task.isCancelled, let sampleBuffer = trackOutput.copyNextSampleBuffer() {
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        let currentSec = CMTimeGetSeconds(pts)
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { continue }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        guard let heatmap = runLiveDepth(pixelBuffer: pixelBuffer, mlModel: mlModel, inputSize: inputSize) else { continue }
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        let fps = 1.0 / max(elapsed, 0.001)
+        let progress = min(currentSec / totalSeconds, 1.0)
+        onFrame(heatmap, progress, fps)
+
+        // Pace to source frame rate when inference is faster than playback,
+        // so a 30fps clip shows at 30fps instead of tearing through in seconds.
+        let sleepTime = max(frameInterval - elapsed, 0)
+        if sleepTime > 0 {
+            try? await Task.sleep(for: .seconds(sleepTime))
+        }
     }
 }
 

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/ImageDetectionDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/ImageDetectionDemoView.swift
@@ -95,20 +95,9 @@ struct ImageDetectionDemoView: View {
 
             // Mode-specific controls
             if mode == .photo {
-                VStack(spacing: 8) {
-                    PhotosPicker(selection: $item, matching: .images) {
-                        Label("Select Photo", systemImage: "photo.badge.plus").frame(maxWidth: .infinity)
-                    }.buttonStyle(.bordered).disabled(isProcessing)
-                }.padding(.horizontal).padding(.bottom, 8)
+                photoControls
             } else if mode == .video {
-                VStack(spacing: 8) {
-                    if videoFrame != nil {
-                        ProgressView(value: videoProgress).tint(.blue).padding(.horizontal)
-                    }
-                    PhotosPicker(selection: $videoItem, matching: .videos) {
-                        Label("Select Video", systemImage: "video.badge.plus").frame(maxWidth: .infinity)
-                    }.buttonStyle(.bordered).disabled(isProcessing)
-                }.padding(.horizontal).padding(.bottom, 8)
+                videoControls
             }
         }
         .task { await loadModel() }
@@ -133,6 +122,37 @@ struct ImageDetectionDemoView: View {
                 .font(.caption2.monospacedDigit()).foregroundStyle(.secondary).frame(width: 36)
         }
         .padding(.horizontal).padding(.bottom, 4)
+    }
+
+    @ViewBuilder
+    private var photoControls: some View {
+        HStack(spacing: 12) {
+            PhotosPicker(selection: $item, matching: .images) {
+                Label("Select Photo", systemImage: "photo.badge.plus").frame(maxWidth: .infinity)
+            }.buttonStyle(.bordered).disabled(isProcessing)
+
+            if let annotated = annotatedImage {
+                Button {
+                    UIImageWriteToSavedPhotosAlbum(annotated, nil, nil, nil)
+                } label: {
+                    Image(systemName: "arrow.down.to.line")
+                }.buttonStyle(.bordered)
+            }
+        }
+        .padding(.horizontal).padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private var videoControls: some View {
+        VStack(spacing: 8) {
+            if videoFrame != nil {
+                ProgressView(value: videoProgress).tint(.blue).padding(.horizontal)
+            }
+            PhotosPicker(selection: $videoItem, matching: .videos) {
+                Label("Select Video", systemImage: "video.badge.plus").frame(maxWidth: .infinity)
+            }.buttonStyle(.bordered).disabled(isProcessing)
+        }
+        .padding(.horizontal).padding(.bottom, 8)
     }
 
     // MARK: - Camera View

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/ImageInOutDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/ImageInOutDemoView.swift
@@ -90,10 +90,12 @@ struct ImageInOutDemoView: View {
                         Label("Select Photo", systemImage: "photo.badge.plus")
                     }.buttonStyle(.bordered).disabled(isProcessing)
 
-                    if outputType == "mask", let output = outputImage {
-                        ShareLink(item: Image(uiImage: output), preview: SharePreview("Result", image: Image(uiImage: output))) {
-                            Image(systemName: "square.and.arrow.up")
-                        }.buttonStyle(.bordered)
+                    if let output = outputImage {
+                        if outputType == "mask" {
+                            ShareLink(item: Image(uiImage: output), preview: SharePreview("Result", image: Image(uiImage: output))) {
+                                Image(systemName: "square.and.arrow.up")
+                            }.buttonStyle(.bordered)
+                        }
 
                         Button {
                             UIImageWriteToSavedPhotosAlbum(output, nil, nil, nil)

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/OpenVocabDetectionDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/OpenVocabDetectionDemoView.swift
@@ -98,6 +98,14 @@ struct OpenVocabDetectionDemoView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(isProcessing || inputImage == nil || queryText.trimmingCharacters(in: .whitespaces).isEmpty)
+
+                    if let annotated = annotatedImage {
+                        Button {
+                            UIImageWriteToSavedPhotosAlbum(annotated, nil, nil, nil)
+                        } label: {
+                            Image(systemName: "arrow.down.to.line")
+                        }.buttonStyle(.bordered)
+                    }
                 }
             }
             .padding()


### PR DESCRIPTION
## Summary

- First public Core ML port of **Depth Anything 3** (ByteDance-Seed, ICLR 2026 oral). No prior public CoreML conversion exists.
- Converts the monocular depth subgraph only — camera / multi-view / sky / 3D Gaussian branches are stripped so the iOS-facing model stays a single-image depth + confidence estimator.
- Two ready-to-use variants for iOS:
  - **DA3 Small** (504×504): 66 MB on disk, 46 MB zipped. DINOv2 ViT-S/14 backbone.
  - **DA3 Base** (504×504): 223 MB on disk, 181 MB zipped. DINOv2 ViT-B/14 backbone.
- Parity vs. PyTorch at FP16: max abs depth diff 0.015 on noise input (range 0.2).

## Changes

- `conversion_scripts/convert_depth_anything_v3.py` — new, reusable for Small / Base / Large / Mono-Large via `--variant`. Bypasses `depth_anything_3.api` (which pulls in moviepy / pycolmap / evo / trimesh / gsplat / plyfile) by loading the net straight from the YAML config + HF safetensors. Five monkey-patches for trace compatibility:
  1. Freeze bicubic-interpolated DINOv2 positional embedding as a buffer.
  2. Freeze the RoPE 2D position grid (`torch.cartesian_prod` is not in coremltools 9.0).
  3. Replace the in-place camera-token write `x[:, :, 0] = cam_token` with a `torch.cat`.
  4. Swap meshgrid-based `create_uv_grid` for a `view + expand + stack` version (coremltools' meshgrid converter rejects traced linspace outputs as non-1d).
  5. Hardcode the monocular `S=1` path in `_get_intermediate_layers_not_chunked` so reference-view reordering and the `b_idx in locals()` guard never fire.
- `sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift` — generalized so it can drive both MoGe-2 (depth + normal + mask + metric_scale) and DA3 (depth + confidence) without a new template. Segmented picker auto-filters modes that have no output, adds a new Confidence heatmap mode, and respects `demo.config.depth_unit` (`meters` vs `relative`) so the range label no longer hardcodes `m`.
- `README.md` — new **Depth Anything 3** section under Monocular Depth Estimation with Small / Base download links.
- `.gitignore` — add `conversion_scripts/DepthAnythingV3/` so the vendored upstream repo never accidentally ships.

## Deployment notes (for the maintainer)

The hub-app manifest draft (`sample_apps/CoreMLModelsApp/models_draft.json`) is gitignored per repo convention, so the DA3 entries live locally only. To ship these to users, upload `DepthAnythingV3_small_504.mlpackage.zip` + `DepthAnythingV3_base_504.mlpackage.zip` to `mlboydaisuke/coreml-zoo/depth_anything_v3/` on HF and promote the local draft entries into `models.json`. Expected SHA-256 and byte sizes are already baked into the local draft:

- Small: 46,274,487 bytes — `c10f8afa01fdc1d22682014824d8e40df67921f96c328f69118ecb725641f78d`
- Base: 181,679,139 bytes — `cd96d12b7d14fb92c312ad1efe771eb1732680578e11bf6b76ab63f4c5d6c51b`

## Test plan

- [ ] Run `python conversion_scripts/convert_depth_anything_v3.py --variant small` and verify parity prints < 1e-3.
- [ ] Run `python conversion_scripts/convert_depth_anything_v3.py --variant base` (takes ~2× Small).
- [ ] Open the hub app on-device, pick a real photo, confirm DA3 depth heatmap + confidence mode render correctly.
- [ ] Confirm MoGe-2 (existing depth model) still works — same template serves both models now.
- [ ] Benchmark tab shows reasonable latency for DA3 Small on Neural Engine / GPU.