### PR TITLE
Align MoGe-2 demo input/output views

### DIFF
--- a/sample_apps/MoGe2Demo/MoGe2Demo/ContentView.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/ContentView.swift
@@ -43,12 +43,12 @@ struct ContentView: View {
                         if depthImage != nil {
                             displayedImage
                                 .resizable()
-                                .aspectRatio(contentMode: .fit)
+                                .aspectRatio(displayAspect, contentMode: .fit)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                         } else if let original = originalImage {
                             Image(uiImage: original)
                                 .resizable()
-                                .aspectRatio(contentMode: .fit)
+                                .aspectRatio(displayAspect, contentMode: .fit)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                         } else {
                             VStack(spacing: 12) {
@@ -136,6 +136,16 @@ struct ContentView: View {
         }
     }
 
+    /// Aspect ratio used to render every view mode. The CoreML outputs are
+    /// 504 × 504 squares (the input was stretched to match the model's
+    /// hard-coded `aspect_ratio = 1.0`), so we restore the original photo's
+    /// proportions on display. When the original isn't loaded yet we fall back
+    /// to square to avoid a divide-by-zero.
+    private var displayAspect: CGFloat {
+        guard let img = originalImage, img.size.height > 0 else { return 1 }
+        return img.size.width / img.size.height
+    }
+
     private func loadImage() {
         guard let item = selectedItem else { return }
         depthImage = nil
@@ -164,12 +174,10 @@ struct ContentView: View {
                 let result = try await estimator.estimate(image: image)
                 let elapsed = CFAbsoluteTimeGetCurrent() - start
                 let depthImg = Visualization.depthImage(
-                    result.depth, size: result.size, dMin: result.depthMin, dMax: result.depthMax,
-                    validX: result.validX, validY: result.validY, validW: result.validW, validH: result.validH
+                    result.depth, size: result.size, dMin: result.depthMin, dMax: result.depthMax
                 )
                 let normalImg = Visualization.normalImage(
-                    result.normal, mask: result.mask, size: result.size,
-                    validX: result.validX, validY: result.validY, validW: result.validW, validH: result.validH
+                    result.normal, mask: result.mask, size: result.size
                 )
                 await MainActor.run {
                     depthImage = depthImg

--- a/sample_apps/MoGe2Demo/MoGe2Demo/DepthEstimator.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/DepthEstimator.swift
@@ -5,12 +5,17 @@ import Accelerate
 /// MoGe-2 ViT-B (504x504, FP16) wrapped in a small Swift driver.
 ///
 /// The CoreML model takes a single ImageType input (`image`) and returns five
-/// outputs: `points`, `depth`, `normal`, `mask`, `metric_scale`. We center-crop
-/// the input UIImage to a square, run inference, and return:
+/// outputs: `points`, `depth`, `normal`, `mask`, `metric_scale`. We stretch
+/// the input UIImage to a 504×504 square, run inference, and return:
 ///
 ///   - depth in metric meters (= raw_depth × metric_scale)
 ///   - per-pixel surface normals in [-1, 1]
 ///   - confidence mask in [0, 1]
+///
+/// The wrapper bakes `aspect_ratio = 1.0` into the UV grids, so stretching the
+/// input is equivalent to what the converted graph assumes anyway; the caller
+/// just applies the original image's aspect at display time to restore the
+/// scene proportions so input and output views overlap pixel-for-pixel.
 ///
 /// Visualization (turbo colormap, normal RGB) lives on the View side.
 final class DepthEstimator: ObservableObject {
@@ -27,11 +32,6 @@ final class DepthEstimator: ObservableObject {
         let depthMin: Float
         let depthMax: Float
         let size: Int
-        // Letterbox: the valid region within the 504x504 output.
-        let validX: Int
-        let validY: Int
-        let validW: Int
-        let validH: Int
     }
 
     init() {
@@ -64,9 +64,9 @@ final class DepthEstimator: ObservableObject {
         let fixed = image.normalizedOrientation()
         guard let cgImage = fixed.cgImage else { throw EstimatorError.invalidImage }
 
-        let (letterboxed, validRect) = letterboxCGImage(cgImage, targetSize: Self.inputSize)
+        let resized = resizeCGImage(cgImage, targetSize: Self.inputSize)
 
-        let pixelBuffer = try makeBGRAPixelBuffer(from: letterboxed)
+        let pixelBuffer = try makeBGRAPixelBuffer(from: resized)
         let input = try MLDictionaryFeatureProvider(dictionary: [
             "image": MLFeatureValue(pixelBuffer: pixelBuffer)
         ])
@@ -111,11 +111,7 @@ final class DepthEstimator: ObservableObject {
             metricScale: metricScale,
             depthMin: dMin,
             depthMax: dMax,
-            size: Self.inputSize,
-            validX: validRect.x,
-            validY: validRect.y,
-            validW: validRect.w,
-            validH: validRect.h
+            size: Self.inputSize
         )
     }
 
@@ -222,21 +218,11 @@ final class DepthEstimator: ObservableObject {
 
     // MARK: - Image helpers
 
-    struct ValidRect { let x: Int; let y: Int; let w: Int; let h: Int }
-
-    /// Letterbox: resize the image so the long side fits `targetSize`, then
-    /// center it on a black `targetSize × targetSize` canvas. Returns the
-    /// composited CGImage and the rect describing where the actual image pixels
-    /// landed (so we can crop the model output back to the original aspect ratio).
-    private func letterboxCGImage(_ image: CGImage, targetSize: Int) -> (CGImage, ValidRect) {
-        let srcW = image.width
-        let srcH = image.height
-        let scale = Float(targetSize) / Float(max(srcW, srcH))
-        let dstW = Int((Float(srcW) * scale).rounded())
-        let dstH = Int((Float(srcH) * scale).rounded())
-        let padX = (targetSize - dstW) / 2
-        let padY = (targetSize - dstH) / 2
-
+    /// Stretch-resize the image to `targetSize × targetSize`. The converted
+    /// MoGe-2 graph hard-codes `aspect_ratio = 1.0` in its UV grids, so a plain
+    /// resize matches what the model expects; the caller reapplies the original
+    /// image's aspect ratio at display time so input and output views overlap.
+    private func resizeCGImage(_ image: CGImage, targetSize: Int) -> CGImage {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let ctx = CGContext(
             data: nil, width: targetSize, height: targetSize,
@@ -244,10 +230,9 @@ final class DepthEstimator: ObservableObject {
             space: colorSpace,
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         )!
-        // Canvas is zero-initialized (black).
         ctx.interpolationQuality = .high
-        ctx.draw(image, in: CGRect(x: padX, y: padY, width: dstW, height: dstH))
-        return (ctx.makeImage()!, ValidRect(x: padX, y: padY, w: dstW, h: dstH))
+        ctx.draw(image, in: CGRect(x: 0, y: 0, width: targetSize, height: targetSize))
+        return ctx.makeImage()!
     }
 
     /// Build a kCVPixelFormatType_32BGRA CVPixelBuffer that the CoreML

--- a/sample_apps/MoGe2Demo/MoGe2Demo/Visualization.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/Visualization.swift
@@ -1,60 +1,52 @@
 import UIKit
 
 /// Visualization helpers: turbo colormap for depth, RGB encoding for normals.
-/// All methods accept the full 504x504 model output and a valid rect that
-/// describes where the actual image content sits (letterbox region). The
-/// returned UIImage is cropped to the valid rect so it matches the original
-/// aspect ratio.
+/// Both methods render the full `size × size` model output. Since the input
+/// was stretch-resized to a square, the output is in square coordinates too;
+/// the caller re-applies the original image's aspect ratio at display time so
+/// the `.original` / `.depth` / `.normal` views overlap pixel-for-pixel.
 enum Visualization {
 
     /// Render a metric depth map as a turbo-colormap UIImage.
-    static func depthImage(
-        _ depth: [Float], size: Int, dMin: Float, dMax: Float,
-        validX: Int, validY: Int, validW: Int, validH: Int
-    ) -> UIImage {
-        var rgba = [UInt8](repeating: 0, count: validW * validH * 4)
+    static func depthImage(_ depth: [Float], size: Int, dMin: Float, dMax: Float) -> UIImage {
+        var rgba = [UInt8](repeating: 0, count: size * size * 4)
         let span = max(dMax - dMin, 1e-3)
-        for row in 0..<validH {
-            let srcRow = (validY + row) * size + validX
-            let dstRow = row * validW
-            for col in 0..<validW {
-                let d = depth[srcRow + col]
+        for row in 0..<size {
+            let base = row * size
+            for col in 0..<size {
+                let d = depth[base + col]
                 if d <= 0 { continue }
                 let t = min(max((d - dMin) / span, 0), 1)
                 let (r, g, b) = turbo(1 - t)
-                let idx = (dstRow + col) * 4
+                let idx = (base + col) * 4
                 rgba[idx] = UInt8(r * 255)
                 rgba[idx + 1] = UInt8(g * 255)
                 rgba[idx + 2] = UInt8(b * 255)
                 rgba[idx + 3] = 255
             }
         }
-        return makeUIImage(rgba: rgba, width: validW, height: validH)
+        return makeUIImage(rgba: rgba, width: size, height: size)
     }
 
     /// Render surface normals as an RGB image.
-    static func normalImage(
-        _ normal: [Float], mask: [Float], size: Int,
-        validX: Int, validY: Int, validW: Int, validH: Int
-    ) -> UIImage {
-        var rgba = [UInt8](repeating: 0, count: validW * validH * 4)
-        for row in 0..<validH {
-            let srcRow = (validY + row) * size + validX
-            let dstRow = row * validW
-            for col in 0..<validW {
-                let si = srcRow + col
+    static func normalImage(_ normal: [Float], mask: [Float], size: Int) -> UIImage {
+        var rgba = [UInt8](repeating: 0, count: size * size * 4)
+        for row in 0..<size {
+            let base = row * size
+            for col in 0..<size {
+                let si = base + col
                 if mask[si] < 0.5 { continue }
                 let nx = normal[si * 3]
                 let ny = -normal[si * 3 + 1]
                 let nz = normal[si * 3 + 2]
-                let idx = (dstRow + col) * 4
+                let idx = si * 4
                 rgba[idx] = UInt8(((nx + 1) * 0.5 * 255).rounded())
                 rgba[idx + 1] = UInt8(((ny + 1) * 0.5 * 255).rounded())
                 rgba[idx + 2] = UInt8(((nz + 1) * 0.5 * 255).rounded())
                 rgba[idx + 3] = 255
             }
         }
-        return makeUIImage(rgba: rgba, width: validW, height: validH)
+        return makeUIImage(rgba: rgba, width: size, height: size)
     }
 
     // MARK: - Turbo colormap (Mikhailov 2019)

--- a/sample_apps/MoGe2Demo/README.md
+++ b/sample_apps/MoGe2Demo/README.md
@@ -29,11 +29,11 @@ This demo uses the **MoGe-2 ViT-B + normal** variant (104 M parameters) at a fix
 
 ## Inference Pipeline (Swift)
 
-1. Center-crop the photo to a square, resize to 504 × 504.
+1. Stretch-resize the photo to 504 × 504 (the converted graph bakes `aspect_ratio = 1.0` into its UV grids, so a plain square resize is what the model expects; the original aspect is restored at display time).
 2. Wrap in a BGRA `CVPixelBuffer` (the model's `ImageType` input applies `scale = 1/255` automatically).
 3. Run `MLModel.prediction`. Read `depth`, `normal`, `mask`, `metric_scale` with **stride-aware** access (the ANE returns non-contiguous strides — see Basic Pitch in `docs/coreml_conversion_notes.md`).
 4. Mask out background pixels and multiply depth by `metric_scale` to get meters.
-5. Render: turbo colormap for depth (near = warm), surface-normal RGB for normals (`nx, -ny, nz` → `r, g, b`).
+5. Render: turbo colormap for depth (near = warm), surface-normal RGB for normals (`nx, -ny, nz` → `r, g, b`). The SwiftUI view re-applies the photo's original aspect so the `original` / `depth` / `normal` toggles line up pixel-for-pixel.
 
 ## Conversion Script
 


### PR DESCRIPTION
## Summary
- Replace the letterbox preprocessor with a plain stretch-resize to 504×504 so the model gets exactly the square the converted graph expects (UV grids are hard-coded to `aspect_ratio=1.0`).
- Restore the original photo's aspect at display time via `aspectRatio(_:contentMode:)`, so toggling `original` / `depth` / `normal` overlaps pixel-for-pixel. The rounding mismatch from the old `validRect` crop is gone.
- Drop the now-unused valid-rect plumbing from `Visualization` and `Result`.
- Update the demo README to describe the new pipeline.

## Test plan
- [ ] Build on device, load a landscape photo, toggle original / depth / normal — views overlap.
- [ ] Same with a portrait photo.
- [ ] Same with a square photo (should be a no-op visually).
- [ ] Depth share sheet still works.