### PR TITLE
Fix ByteTracker access level for Det typealias

### DIFF
--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Views/ByteTracker.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Views/ByteTracker.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 // Reference: Zhang et al., "ByteTrack: Multi-Object Tracking by
 // Associating Every Detection Box", ECCV 2022 (arxiv 2110.06864).
 
-fileprivate typealias Det = BoundingBoxOverlay.DetectionBox
+typealias Det = BoundingBoxOverlay.DetectionBox
 
 final class ByteTracker {
 


### PR DESCRIPTION
## Summary
- The `Det` typealias in `ByteTracker.swift` was `fileprivate`, but `ByteTracker.update(detections:)` is internal and is called from `ImageDetectionDemoView`. Swift rejects this (compiler error: "Method must be declared fileprivate because its parameter uses a fileprivate type").
- Drop the `fileprivate` qualifier so the alias defaults to internal, matching `ByteTracker`'s visibility.

## Test plan
- [ ] Build the hub app on device.