### PR TITLE
Stop MoGe-2 visualizer from drawing transparent mask bands

### DIFF
--- a/sample_apps/MoGe2Demo/MoGe2Demo/DepthEstimator.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/DepthEstimator.swift
@@ -89,20 +89,26 @@ final class DepthEstimator: ObservableObject {
         // normal: (1, H, W, 3)
         let normal = readMultiArray3D(normalArr, height: Self.inputSize, width: Self.inputSize, channels: 3)
 
-        // Apply mask × metric_scale to depth, ignoring the background.
+        // Multiply by metric_scale for every pixel. Confident pixels (mask > 0.5)
+        // set the dMin/dMax range so the colormap stays tight; low-confidence
+        // regions (usually sky) keep their raw prediction and get clamped into
+        // the same range by the visualizer, so they take the "far" end of turbo
+        // instead of appearing as black bands that look like letterbox padding.
         var metricDepth = [Float](repeating: 0, count: depth.count)
         var dMin: Float = .greatestFiniteMagnitude
         var dMax: Float = 0
         for i in 0..<depth.count {
-            let valid = mask[i] > 0.5
-            let d = valid ? depth[i] * metricScale : 0
+            let d = depth[i] * metricScale
             metricDepth[i] = d
-            if valid {
+            if mask[i] > 0.5 {
                 if d < dMin { dMin = d }
                 if d > dMax { dMax = d }
             }
         }
-        if dMin == .greatestFiniteMagnitude { dMin = 0 }
+        if dMin == .greatestFiniteMagnitude {
+            dMin = 0
+            dMax = 1
+        }
 
         return Result(
             depth: metricDepth,

--- a/sample_apps/MoGe2Demo/MoGe2Demo/Visualization.swift
+++ b/sample_apps/MoGe2Demo/MoGe2Demo/Visualization.swift
@@ -7,7 +7,10 @@ import UIKit
 /// the `.original` / `.depth` / `.normal` views overlap pixel-for-pixel.
 enum Visualization {
 
-    /// Render a metric depth map as a turbo-colormap UIImage.
+    /// Render a metric depth map as a turbo-colormap UIImage. Every pixel gets
+    /// a colour — low-confidence regions (sky/background) are clamped into the
+    /// "far" end of the colormap instead of being rendered transparent, so the
+    /// output never shows letterbox-looking black bands.
     static func depthImage(_ depth: [Float], size: Int, dMin: Float, dMax: Float) -> UIImage {
         var rgba = [UInt8](repeating: 0, count: size * size * 4)
         let span = max(dMax - dMin, 1e-3)
@@ -15,7 +18,6 @@ enum Visualization {
             let base = row * size
             for col in 0..<size {
                 let d = depth[base + col]
-                if d <= 0 { continue }
                 let t = min(max((d - dMin) / span, 0), 1)
                 let (r, g, b) = turbo(1 - t)
                 let idx = (base + col) * 4
@@ -28,14 +30,16 @@ enum Visualization {
         return makeUIImage(rgba: rgba, width: size, height: size)
     }
 
-    /// Render surface normals as an RGB image.
+    /// Render surface normals as an RGB image. `mask` is accepted for API
+    /// symmetry with `depthImage` but not consulted — skipping low-mask pixels
+    /// used to leave transparent bands that looked like letterbox padding.
     static func normalImage(_ normal: [Float], mask: [Float], size: Int) -> UIImage {
+        _ = mask
         var rgba = [UInt8](repeating: 0, count: size * size * 4)
         for row in 0..<size {
             let base = row * size
             for col in 0..<size {
                 let si = base + col
-                if mask[si] < 0.5 { continue }
                 let nx = normal[si * 3]
                 let ny = -normal[si * 3 + 1]
                 let nz = normal[si * 3 + 2]


### PR DESCRIPTION
## Summary
- Depth and normal visualizers used to skip pixels where the mask was low (or depth was 0 after the estimator zeroed them). After the switch to stretch-resize, those skipped pixels line up along the top / bottom of the scene (sky, featureless background) and render as transparent bands that look exactly like letterbox padding.
- Render every pixel: confident pixels still drive `dMin` / `dMax`, but low-confidence regions are clamped into the "far" end of the turbo colormap instead of being punched out.
- Normal visualizer no longer reads the mask either (kept in the signature for callers).

## Test plan
- [ ] Run on device with a landscape photo that has sky: no black top/bottom band in depth or normal view.
- [ ] Portrait photo with sky: same.
- [ ] Indoor photo (no sky): looks the same as before.