### PR TITLE
Add video input to Gemma 4 E2B chat in CoreMLModelsApp

### DIFF
--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp.xcodeproj/project.pbxproj
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 			repositoryURL = "https://github.com/john-rocky/CoreML-LLM";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.0;
+				minimumVersion = 0.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Model/ModelLoader.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Model/ModelLoader.swift
@@ -236,6 +236,38 @@ enum ImageUtils {
         return pixelBuffer(from: cg, width: width, height: height)
     }
 
+    /// Stretch-resize a CGImage into a square of `size` — no aspect
+    /// preservation, no padding. Callers that want the result to look
+    /// aspect-correct on screen must re-apply the source aspect at display
+    /// time. Used by the depth/normal templates so the input and output
+    /// heatmap don't carry visible black letterbox bands.
+    static func stretchResize(_ cgImage: CGImage, size: Int) -> CVPixelBuffer? {
+        let attrs: [String: Any] = [
+            kCVPixelBufferCGImageCompatibilityKey as String: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey as String: true
+        ]
+        var pb: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, size, size,
+                            kCVPixelFormatType_32BGRA, attrs as CFDictionary, &pb)
+        guard let buf = pb else { return nil }
+
+        CVPixelBufferLockBaseAddress(buf, [])
+        defer { CVPixelBufferUnlockBaseAddress(buf, []) }
+
+        guard let ctx = CGContext(
+            data: CVPixelBufferGetBaseAddress(buf),
+            width: size, height: size,
+            bitsPerComponent: 8,
+            bytesPerRow: CVPixelBufferGetBytesPerRow(buf),
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else { return nil }
+
+        ctx.interpolationQuality = .high
+        ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: size, height: size))
+        return buf
+    }
+
     /// Letterbox a CGImage into a square of `size`, returning the buffer and the content rect.
     static func letterbox(_ cgImage: CGImage, size: Int) -> (CVPixelBuffer, CGRect)? {
         let w = cgImage.width, h = cgImage.height

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/ChatDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/ChatDemoView.swift
@@ -7,8 +7,8 @@ import AVFoundation
 /// Used by: Gemma 4 E2B (multimodal), Qwen2.5-0.5B (text-only).
 ///
 /// Uses CoreML-LLM package for ANE-optimized on-device inference.
-/// Supports multimodal input (text + image + audio) when the loaded model
-/// includes the respective encoders.
+/// Supports multimodal input (text + image + audio + video) when the loaded
+/// model includes the respective encoders.
 struct ChatDemoView: View {
     let model: ModelEntry
 
@@ -23,6 +23,11 @@ struct ChatDemoView: View {
     @State private var tokensPerSecond: Double?
     @State private var hasVision = false
     @State private var hasAudio = false
+    @State private var hasVideo = false
+    @State private var selectedVideoURL: URL?
+    @State private var videoPickerItem: PhotosPickerItem?
+    @State private var videoThumbnail: UIImage?
+    @State private var videoDuration: TimeInterval = 0
     @StateObject private var audioRecorder = ChatAudioRecorder()
 
     var body: some View {
@@ -73,6 +78,30 @@ struct ChatDemoView: View {
                     .padding(.horizontal)
                 }
 
+                // Video preview
+                if selectedVideoURL != nil {
+                    HStack {
+                        ZStack {
+                            if let thumb = videoThumbnail {
+                                Image(uiImage: thumb).resizable().aspectRatio(contentMode: .fill)
+                                    .frame(width: 60, height: 60).clipShape(RoundedRectangle(cornerRadius: 8))
+                            } else {
+                                RoundedRectangle(cornerRadius: 8).fill(.gray.opacity(0.25))
+                                    .frame(width: 60, height: 60)
+                            }
+                            Image(systemName: "play.circle.fill")
+                                .font(.title3).foregroundStyle(.white).shadow(radius: 2)
+                        }
+                        Text(videoDuration > 0 ? String(format: "Video · %.1fs", videoDuration) : "Video")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Spacer()
+                        Button { clearVideo() } label: {
+                            Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+
                 // Audio preview (recording / ready-to-send)
                 if hasAudio && (audioRecorder.isRecording || audioRecorder.recordedSamples != nil) {
                     HStack(spacing: 8) {
@@ -100,6 +129,14 @@ struct ChatDemoView: View {
                             Image(systemName: "photo").font(.title3)
                         }
                         .onChange(of: photoItem) { _, item in loadImage(item) }
+                        .disabled(isGenerating || selectedVideoURL != nil)
+                    }
+
+                    if hasVideo {
+                        PhotosPicker(selection: $videoPickerItem, matching: .videos) {
+                            Image(systemName: "video").font(.title3)
+                        }
+                        .onChange(of: videoPickerItem) { _, item in loadVideo(item) }
                         .disabled(isGenerating)
                     }
 
@@ -109,7 +146,7 @@ struct ChatDemoView: View {
                                 .font(.title3)
                                 .foregroundStyle(audioRecorder.isRecording ? .red : .accentColor)
                         }
-                        .disabled(isGenerating)
+                        .disabled(isGenerating || selectedVideoURL != nil)
                     }
 
                     TextField("Message…", text: $inputText, axis: .vertical)
@@ -137,6 +174,7 @@ struct ChatDemoView: View {
         .onDisappear {
             audioRecorder.stop()
             audioRecorder.clear()
+            clearVideo()
             llm?.reset()
             llm = nil
             messages.removeAll()
@@ -147,7 +185,8 @@ struct ChatDemoView: View {
         guard !isGenerating, llm != nil else { return true }
         let hasText = !inputText.trimmingCharacters(in: .whitespaces).isEmpty
         let hasAudioClip = audioRecorder.recordedSamples != nil
-        return !(hasText || hasAudioClip)
+        let hasVideoClip = selectedVideoURL != nil
+        return !(hasText || hasAudioClip || hasVideoClip)
     }
 
     // MARK: - Model Loading
@@ -169,6 +208,10 @@ struct ChatDemoView: View {
                 llm = loaded
                 hasVision = loaded.supportsVision
                 hasAudio = loaded.supportsAudio
+                // CoreMLLLM 0.8 ships a video encoder only for Gemma 4 E2B.
+                // There is no public supportsVideo flag yet, so gate on the
+                // manifest id of the single currently-capable model.
+                hasVideo = loaded.supportsVision && model.id == "gemma4_e2b"
                 audioRecorder.maxDuration = loaded.maxAudioDuration
                 isLoading = false
                 status = ""
@@ -195,22 +238,36 @@ struct ChatDemoView: View {
     private func send() {
         let text = inputText.trimmingCharacters(in: .whitespaces)
         let audio = audioRecorder.recordedSamples
-        guard let llm, !isGenerating, !text.isEmpty || audio != nil else { return }
+        let videoURL = selectedVideoURL
+        guard let llm, !isGenerating,
+              !text.isEmpty || audio != nil || videoURL != nil else { return }
 
         let image = selectedImage?.cgImage
         let displayImage = selectedImage
+        let displayVideoThumbnail = videoThumbnail
         inputText = ""
         selectedImage = nil
         photoItem = nil
         audioRecorder.clear()
+        // Keep the temp file on disk until the stream finishes; just drop the
+        // UI state so the user sees the composer clear immediately.
+        selectedVideoURL = nil
+        videoPickerItem = nil
+        videoThumbnail = nil
+        videoDuration = 0
 
-        // Label audio-only sends so the transcript still shows something visible.
+        // Label audio/video-only sends so the transcript still shows something visible.
         let displayText: String
-        if text.isEmpty, audio != nil { displayText = "[Audio]" }
-        else if audio != nil { displayText = "[Audio] " + text }
-        else { displayText = text }
+        if videoURL != nil {
+            displayText = text.isEmpty ? "[Video]" : "[Video] " + text
+        } else if audio != nil {
+            displayText = text.isEmpty ? "[Audio]" : "[Audio] " + text
+        } else {
+            displayText = text
+        }
 
-        messages.append(ChatMessage(role: .user, content: displayText, image: displayImage))
+        messages.append(ChatMessage(role: .user, content: displayText,
+                                    image: displayImage ?? displayVideoThumbnail))
         messages.append(ChatMessage(role: .assistant, content: ""))
 
         isGenerating = true
@@ -221,7 +278,16 @@ struct ChatDemoView: View {
             var tokenCount = 0
 
             do {
-                for await token in try await llm.stream(text, image: image, audio: audio, maxTokens: 1024) {
+                let stream: AsyncStream<String>
+                if let videoURL {
+                    stream = try await llm.stream(text, videoURL: videoURL,
+                                                  videoOptions: .init(),
+                                                  maxTokens: 1024)
+                } else {
+                    stream = try await llm.stream(text, image: image, audio: audio,
+                                                  maxTokens: 1024)
+                }
+                for await token in stream {
                     tokenCount += 1
                     await MainActor.run {
                         if var last = messages.last, last.role == .assistant {
@@ -233,6 +299,10 @@ struct ChatDemoView: View {
                 await MainActor.run {
                     messages[messages.count - 1].content += "\n[Error: \(error.localizedDescription)]"
                 }
+            }
+
+            if let videoURL {
+                try? FileManager.default.removeItem(at: videoURL)
             }
 
             let elapsed = CFAbsoluteTimeGetCurrent() - start
@@ -267,9 +337,67 @@ struct ChatDemoView: View {
         Task {
             if let data = try? await item.loadTransferable(type: Data.self),
                let img = UIImage(data: data) {
-                await MainActor.run { selectedImage = img }
+                await MainActor.run {
+                    selectedImage = img
+                    // Image and video are mutually exclusive — CoreMLLLM's
+                    // video stream has no image parameter.
+                    clearVideo()
+                }
             }
         }
+    }
+
+    private func loadVideo(_ item: PhotosPickerItem?) {
+        guard let item else { return }
+        Task {
+            guard let data = try? await item.loadTransferable(type: Data.self) else { return }
+            let tmpURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("chat_video_\(UUID().uuidString).mp4")
+            do {
+                try data.write(to: tmpURL)
+            } catch {
+                print("[Chat] Failed to stage video: \(error)")
+                return
+            }
+            let asset = AVURLAsset(url: tmpURL)
+            let duration = (try? await asset.load(.duration).seconds) ?? 0
+            let thumb = await generateVideoThumbnail(asset: asset)
+            await MainActor.run {
+                // Clear other modalities — video stream API is exclusive.
+                selectedImage = nil
+                photoItem = nil
+                audioRecorder.clear()
+                selectedVideoURL = tmpURL
+                videoThumbnail = thumb
+                videoDuration = duration
+            }
+        }
+    }
+
+    private func generateVideoThumbnail(asset: AVURLAsset) async -> UIImage? {
+        let gen = AVAssetImageGenerator(asset: asset)
+        gen.appliesPreferredTrackTransform = true
+        gen.maximumSize = CGSize(width: 240, height: 240)
+        let t = CMTime(seconds: 0.1, preferredTimescale: 600)
+        return await withCheckedContinuation { continuation in
+            gen.generateCGImagesAsynchronously(forTimes: [NSValue(time: t)]) { _, cg, _, _, _ in
+                if let cg {
+                    continuation.resume(returning: UIImage(cgImage: cg))
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+
+    private func clearVideo() {
+        if let url = selectedVideoURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+        selectedVideoURL = nil
+        videoPickerItem = nil
+        videoThumbnail = nil
+        videoDuration = 0
     }
 }
 

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
@@ -24,6 +24,11 @@ struct DepthVisualizationDemoView: View {
     @State private var isProcessing = false
     @State private var status = ""
     @State private var item: PhotosPickerItem?
+    // Aspect ratio of the source image/frame. The model takes a square
+    // stretch-resized input and emits square outputs; we replay the source
+    // aspect at display time so the depth/normal/confidence views line up
+    // with the original and neither preview shows black letterbox bands.
+    @State private var sourceAspect: CGFloat = 1.0
 
     // Camera-mode state. `mlModel` is cached on load so the per-frame
     // callback can run prediction without awaiting the session.
@@ -130,7 +135,8 @@ struct DepthVisualizationDemoView: View {
     @ViewBuilder
     private var displayArea: some View {
         if let img = currentDisplayImage {
-            Image(uiImage: img).resizable().aspectRatio(contentMode: .fit)
+            Image(uiImage: img).resizable()
+                .aspectRatio(sourceAspect, contentMode: .fit)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             VStack(spacing: 12) {
@@ -191,7 +197,8 @@ struct DepthVisualizationDemoView: View {
             .opacity(liveDepth == nil ? 1 : 0.001)
 
             if let depth = liveDepth {
-                Image(uiImage: depth).resizable().aspectRatio(contentMode: .fit)
+                Image(uiImage: depth).resizable()
+                    .aspectRatio(sourceAspect, contentMode: .fit)
             }
 
             if mlModel == nil {
@@ -218,7 +225,8 @@ struct DepthVisualizationDemoView: View {
     private var videoContent: some View {
         ZStack {
             if let depth = liveDepth {
-                Image(uiImage: depth).resizable().aspectRatio(contentMode: .fit)
+                Image(uiImage: depth).resizable()
+                    .aspectRatio(sourceAspect, contentMode: .fit)
             } else {
                 VStack(spacing: 12) {
                     Image(systemName: "film").font(.system(size: 60)).foregroundStyle(.secondary)
@@ -275,6 +283,7 @@ struct DepthVisualizationDemoView: View {
         isInferring = true
 
         let inputSize = model.configInt("input_size") ?? 504
+        let aspect = CGFloat(CVPixelBufferGetWidth(pb)) / CGFloat(max(CVPixelBufferGetHeight(pb), 1))
 
         Task.detached(priority: .userInitiated) {
             let start = CFAbsoluteTimeGetCurrent()
@@ -282,6 +291,7 @@ struct DepthVisualizationDemoView: View {
             let elapsed = CFAbsoluteTimeGetCurrent() - start
             await MainActor.run {
                 if heatmap != nil { liveDepth = heatmap }
+                sourceAspect = aspect
                 let fps = 1.0 / max(elapsed, 0.001)
                 liveFps = liveFps == 0 ? fps : liveFps * 0.9 + fps * 0.1
                 isInferring = false
@@ -301,7 +311,12 @@ struct DepthVisualizationDemoView: View {
                     await MainActor.run { isProcessing = false; status = "Invalid image data" }
                     return
                 }
-                await MainActor.run { inputImage = img }
+                await MainActor.run {
+                    inputImage = img
+                    // Pre-set so the freshly-shown input isn't briefly rendered
+                    // with the previous photo's aspect ratio.
+                    sourceAspect = img.size.width / max(img.size.height, 1)
+                }
                 await runDepth(on: img)
             } catch {
                 await MainActor.run { isProcessing = false; status = "Load error: \(error.localizedDescription)" }
@@ -321,10 +336,12 @@ struct DepthVisualizationDemoView: View {
                 return
             }
 
-            guard let (pb, _) = ImageUtils.letterbox(cgImage, size: inputSize) else {
-                await MainActor.run { isProcessing = false; status = "Letterbox failed" }
+            guard let pb = ImageUtils.stretchResize(cgImage, size: inputSize) else {
+                await MainActor.run { isProcessing = false; status = "Preprocess failed" }
                 return
             }
+            let aspect = CGFloat(cgImage.width) / CGFloat(max(cgImage.height, 1))
+            await MainActor.run { sourceAspect = aspect }
 
             let inputName = mlModel.modelDescription.inputDescriptionsByName.first {
                 $0.value.type == .image
@@ -389,9 +406,10 @@ struct DepthVisualizationDemoView: View {
             let inputSize = model.configInt("input_size") ?? 504
             guard let mlModel else { return }
             videoTask = Task.detached(priority: .userInitiated) {
-                await runDepthVideo(url: url, mlModel: mlModel, inputSize: inputSize) { frame, progress, fps in
+                await runDepthVideo(url: url, mlModel: mlModel, inputSize: inputSize) { frame, progress, fps, aspect in
                     Task { @MainActor in
                         liveDepth = frame
+                        sourceAspect = aspect
                         videoProgress = progress
                         liveFps = liveFps == 0 ? fps : liveFps * 0.9 + fps * 0.1
                     }
@@ -473,7 +491,7 @@ private func runDepthVideo(
     url: URL,
     mlModel: MLModel,
     inputSize: Int,
-    onFrame: @escaping (UIImage, Double, Double) -> Void
+    onFrame: @escaping (UIImage, Double, Double, CGFloat) -> Void
 ) async {
     let asset = AVURLAsset(url: url)
     guard let track = try? await asset.loadTracks(withMediaType: .video).first else { return }
@@ -498,7 +516,9 @@ private func runDepthVideo(
         let elapsed = CFAbsoluteTimeGetCurrent() - start
         let fps = 1.0 / max(elapsed, 0.001)
         let progress = min(currentSec / totalSeconds, 1.0)
-        onFrame(heatmap, progress, fps)
+        let aspect = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
+            / CGFloat(max(CVPixelBufferGetHeight(pixelBuffer), 1))
+        onFrame(heatmap, progress, fps, aspect)
 
         // Pace to source frame rate when inference is faster than playback,
         // so a 30fps clip shows at 30fps instead of tearing through in seconds.
@@ -517,7 +537,7 @@ private func runLiveDepth(pixelBuffer: CVPixelBuffer, mlModel: MLModel, inputSiz
     let ci = CIImage(cvPixelBuffer: pixelBuffer)
     let ctx = CIContext(options: [.useSoftwareRenderer: false])
     guard let cg = ctx.createCGImage(ci, from: ci.extent) else { return nil }
-    guard let (pb, _) = ImageUtils.letterbox(cg, size: inputSize) else { return nil }
+    guard let pb = ImageUtils.stretchResize(cg, size: inputSize) else { return nil }
 
     let inputName = mlModel.modelDescription.inputDescriptionsByName.first {
         $0.value.type == .image

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/DepthVisualizationDemoView.swift
@@ -376,6 +376,14 @@ struct DepthVisualizationDemoView: View {
             var confResult: UIImage?
             if let confArr { confResult = buildConfidenceHeatmap(confArr) }
 
+            // Resize square model outputs back to the source image's pixel
+            // dimensions so saves/shares match the original resolution and
+            // aspect — not the 504-square the model predicts at.
+            let targetSize = CGSize(width: cgImage.width, height: cgImage.height)
+            if let d = depthResult { depthResult = ImageUtils.resize(d, to: targetSize) ?? d }
+            if let n = normalResult { normalResult = ImageUtils.resize(n, to: targetSize) ?? n }
+            if let c = confResult { confResult = ImageUtils.resize(c, to: targetSize) ?? c }
+
             await MainActor.run {
                 depthImage = depthResult
                 normalImage = normalResult

--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/VideoMattingDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/VideoMattingDemoView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PhotosUI
+import Photos
 import CoreML
 import AVFoundation
 import AVKit
@@ -102,10 +103,28 @@ struct VideoMattingDemoView: View {
             }
 
             if let url = outputVideoURL {
-                VideoPlayerView(url: url)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .padding(.horizontal)
+                VStack(spacing: 8) {
+                    VideoPlayerView(url: url)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                    HStack(spacing: 12) {
+                        Button {
+                            Task { await saveOutputToPhotos(url) }
+                        } label: {
+                            Label("Save", systemImage: "square.and.arrow.down")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+
+                        ShareLink(item: url) {
+                            Label("Share", systemImage: "square.and.arrow.up")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+                .padding(.horizontal)
             } else {
                 VStack(spacing: 12) {
                     Image(systemName: "person.and.background.dotted")
@@ -236,6 +255,25 @@ struct VideoMattingDemoView: View {
                 isProcessing = false
                 status = "Error: \(error.localizedDescription)"
             }
+        }
+    }
+
+    /// Save the matted output video to the user's Photos library. Requests
+    /// add-only authorization — which pairs with the NSPhotoLibraryAdd
+    /// usage description already present in Info.plist.
+    private func saveOutputToPhotos(_ url: URL) async {
+        let auth = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        guard auth == .authorized || auth == .limited else {
+            await MainActor.run { status = "Photo library access denied" }
+            return
+        }
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                PHAssetCreationRequest.creationRequestForAssetFromVideo(atFileURL: url)
+            }
+            await MainActor.run { status = "Saved to Photos" }
+        } catch {
+            await MainActor.run { status = "Save failed: \(error.localizedDescription)" }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bump the `CoreML-LLM` SPM minimum version from 0.5.0 to 0.7.0 (0.8.0 is the current latest) so the hub app can call the new `stream(_:videoURL:videoOptions:)` API.
- Add a `PhotosPicker(matching: .videos)` button, a thumbnail + duration preview tile, and a video-exclusive send path to `ChatDemoView`. Picking a video clears the image/audio modalities (CoreMLLLM's video stream API has no `image:`/`audio:` params) and the temp file is cleaned up when the stream finishes.
- Gate the video UI on `model.id == "gemma4_e2b"` because only Gemma 4 E2B currently ships a video encoder and CoreMLLLM does not yet expose a public `supportsVideo` flag.

## Test plan
- [ ] Build the `CoreMLModelsApp` target; Xcode should resolve `CoreML-LLM` to >= 0.7.0.
- [ ] Open Gemma 4 E2B → chat and confirm the new video button appears between the photo and mic buttons.
- [ ] Pick a short MP4 from the library, confirm the thumbnail tile + duration render, then send with and without a text prompt and verify streaming output (per-frame description).
- [ ] Confirm picking a video clears any staged image/audio, and picking an image/starting a recording clears the video.
- [ ] Open Qwen2.5-0.5B and Gemma 4 E4B chats and confirm the video button is hidden.