### PR TITLE
Fix Florence-2 Detailed Caption and OCR in hub app

### DIFF
--- a/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/ImageToTextDemoView.swift
+++ b/sample_apps/CoreMLModelsApp/CoreMLModelsApp/Templates/ImageToTextDemoView.swift
@@ -3,8 +3,8 @@ import PhotosUI
 import CoreML
 
 /// Image captioning with Photo + Camera tabs.
-/// Matches Florence2Demo: task picker (Caption/Detailed/OCR), real-time camera captioning,
-/// question input for VQA mode, copy button.
+/// Matches Florence2Demo: task picker (Caption / Detailed / More Detail / OCR),
+/// real-time camera captioning, copy button.
 struct ImageToTextDemoView: View {
     let model: ModelEntry
 
@@ -12,8 +12,25 @@ struct ImageToTextDemoView: View {
     enum CaptionTask: String, CaseIterable, Identifiable {
         case caption = "Caption"
         case detailed = "Detailed"
+        case moreDetailed = "More Detail"
         case ocr = "OCR"
         var id: String { rawValue }
+
+        /// Florence-2 prompt tokens. Matches `Florence2Task.inputIDs` in the
+        /// Florence2Demo sample app. Hardcoded (not read from the manifest)
+        /// because the prompts are intrinsic to Florence-2.
+        var inputIDs: [Int] {
+            switch self {
+            case .caption:
+                return [0, 2264, 473, 5, 2274, 6190, 116, 2]
+            case .detailed:
+                return [0, 47066, 21700, 11, 4617, 99, 16, 2343, 11, 5, 2274, 4, 2]
+            case .moreDetailed:
+                return [0, 47066, 21700, 19, 10, 17818, 99, 16, 2343, 11, 5, 2274, 4, 2]
+            case .ocr:
+                return [0, 2264, 16, 5, 2788, 11, 5, 2274, 116, 2]
+            }
+        }
     }
 
     @State private var tab: Tab = .photo
@@ -271,17 +288,7 @@ struct ImageToTextDemoView: View {
             veOutput.featureValue(for: $0)?.multiArrayValue
         }.first
 
-        // Task input IDs
-        let taskIds: [Int]
-        if let tasks = model.demo.config?["tasks"]?.value as? [String: Any],
-           let ids = tasks[task.rawValue.lowercased()] as? [Int] {
-            taskIds = ids
-        } else if let tasks = model.demo.config?["tasks"]?.value as? [String: Any],
-                  let ids = tasks[task.rawValue.lowercased().replacingOccurrences(of: " ", with: "_")] as? [Int] {
-            taskIds = ids
-        } else {
-            taskIds = [0, 2]
-        }
+        let taskIds = task.inputIDs
 
         // Text encode
         var encoderHiddenStates: MLMultiArray?


### PR DESCRIPTION
## Summary
- Hub's `ImageToTextDemoView` looked up task token IDs via `task.rawValue.lowercased()` ("detailed"), but the manifest key is `detailed_caption`, so Detailed fell through to the `[0, 2]` default and produced empty output.
- Manifest's `ocr` token IDs were also wrong (caption-shaped), so OCR returned a regular caption.
- Hardcode Florence-2 prompt tokens in `CaptionTask.inputIDs` to match `Florence2Captioner.inputIDs` in the Florence2Demo sample app. Added **More Detail** to match the sample app's four-task picker.

Prompt tokens are intrinsic to Florence-2, so reading them from the manifest was unnecessary indirection (and the source of this bug). The manifest's `tasks` map is no longer consulted.

## Test plan
- [ ] Open Florence-2 in the hub app on device
- [ ] Pick a photo, select **Detailed** → verify a longer description is produced (not empty)
- [ ] Select **More Detail** → verify an even longer description
- [ ] Select **OCR** on an image containing text → verify extracted text, not a generic caption
- [ ] Confirm **Caption** still works unchanged